### PR TITLE
Add declarative-designs skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ bin/.*
 !.claude/agents/*.md
 !.claude/.mcp.json
 
+# Skills
+!.skills
+!.skills/**
+
 # Explicitly ignore
 .bashrc
 .kiro/settings/mcp.json

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,15 +5,15 @@ description: Objectives for design-driven development. Load when authoring desig
 
 # Declarative Designs
 
-Designs are source. Implementations are compiled from them. The agent closes the gap between current implementation and declared design, continuously and proactively.
+Designs are source. Implementations are compiled from them. The gap between current implementation and declared design closes continuously.
 
 ## At Rest
 
 - Implementations satisfy all objectives, constraints, and quality attributes declared in the design
-- Where a design is silent, the agent makes implementation choices freely and improves them over time
+- Where a design is silent, implementation choices are unconstrained and improve over time
 - Test coverage validates design commitments, not implementation details
 - Documentation accurately reflects the current design
-- The agent proactively identifies gaps between design and implementation without waiting to be asked
+- Gaps between design and implementation do not persist
 
 ## On Change
 
@@ -25,4 +25,4 @@ Designs are source. Implementations are compiled from them. The agent closes the
 
 - Designs declare intent, constraints, and quality attributes — not mechanism
 - Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design
-- When a design prescribes implementation, the agent flags it and proposes a revision that captures the underlying intent
+- Implementation details in a design are revised to capture the underlying intent

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,25 +5,27 @@ description: How to author, implement from, and reconcile toward declarative des
 
 # Declarative Designs
 
-Declare what a system is, what properties it has, and what constraints it operates under — not how.
-Implementations converge toward the design continuously. The design is the control plane. The code is
-the data plane. Speed comes from declaring only what matters and leaving the rest as freedom.
+A declarative design transfers a human's judgment into a persistent artifact that agents reconcile
+toward. It declares what a system is, what properties it has, and what constraints it operates
+under — not how. The design makes the human's judgment persistent and the agent's work cumulative.
+Without it, every session starts from zero, work doesn't accumulate, and quality depends on the human
+reviewing everything — which doesn't scale at agent speed.
 
-## The model
+A design is sparse because the human's time is the scarce resource. It captures intent because intent
+persists across implementation changes. It is evaluable because the human can't review every line — if
+the design is satisfied, the implementation is acceptable even if the human hasn't read it. The
+design is the control plane. The code is the data plane. This is how any control system works: a
+stable reference, a feedback loop, and a process that closes the error.
 
-A declarative design is a desired state declaration. It persists across sessions, refactors, and
-rewrites, and the implementation gets better against it each time. This is how any control system
-works: a stable reference, a feedback loop, and a process that closes the error.
+This is not spec-and-implement. A spec is consumed once and goes stale. A design persists across
+sessions, refactors, and rewrites, and the implementation gets better against it each time. As an
+artifact, a design is text that occupies a context window, competes for attention, and steers work.
+Every constraint that follows — compression, specificity, sparseness — is a consequence of this form.
+A thesis that builds understanding is more durable than a list of assertions. Every sentence that
+does not carry weight degrades the ones that do. Designs grow in specificity over time, not in
+length.
 
-This is not spec-and-implement. A spec is consumed once and goes stale. A design persists because it
-captures intent rather than mechanism — and intent survives the technology transitions that make specs
-obsolete. The design cost is paid once. Everything after that is convergence.
-
-As an artifact, a design is text that occupies a context window, competes for attention, and steers
-work. Every constraint that follows — compression, specificity, sparseness — is a consequence of this
-form.
-
-## What makes a design work
+## Writing designs
 
 ### Intent
 
@@ -31,6 +33,14 @@ A design captures what and why. Consider a messaging system: "Producers and cons
 Messages are delivered at least once. Ordering is preserved within a partition key. Consumers are
 independently scalable." This says what the system promises without prescribing how. The
 implementation can use Kafka today and in-process channels tomorrow. The design survives both.
+
+The failure mode is overspecification. "Use Kafka with three partitions, JSON serialization, and
+consumer groups for fan-out." The design has prescribed the implementation. Swap to in-process
+channels for testing? Redesign. The design spent its budget on the part that changes and left nothing
+for the part that persists.
+
+_Test: can the implementation change without the design changing? If not, the design has captured
+mechanism._
 
 ### Sparseness
 
@@ -40,78 +50,39 @@ The controller fills that silence, and fills it differently as conditions change
 distinguishes a design from a spec: a spec tries to be complete. A design is powerful because it is
 sparse. Sparseness is where implementations improve over time without the design changing.
 
-A design occupies a context window. A thesis that builds understanding — where each idea follows from
-the previous and a reader can extend the reasoning — is more durable than a list of assertions. Every
-sentence that does not carry weight degrades the ones that do. Designs grow in specificity over time,
-not in length.
+A design operates at the altitude where changing a commitment changes the product. If something can
+change without the product changing, it belongs in the implementation. If it cannot, it belongs in the
+design. This boundary between commitment and freedom is the most important thing a design
+communicates. A design that starts at the right altitude and gradually descends into interface
+details, flag names, or behavioral specifications has lost the boundary. Hold the altitude.
 
 ### Specificity
 
 Sparseness is not vagueness. A design must be specific enough that an implementation can fail to
-satisfy it. "P99 latency under 100ms at 1000 concurrent connections" can be reconciled toward. "The
-system is performant" cannot — it provides no signal. Specificity is what makes the feedback loop
-functional.
+satisfy it. The messaging system's "at least once" is specific — an implementation that drops messages
+under backpressure has failed. "P99 latency under 100ms at 1000 concurrent connections" can be
+reconciled toward. Specificity is what makes the feedback loop functional.
 
-The altitude test: if something can change without the product changing, it belongs in the
-implementation. If it cannot, it belongs in the design. This boundary between commitment and freedom
-is the most important thing a design communicates.
-
-## What breaks a design
-
-### Overspecified
-
-"Use Kafka with three partitions, JSON serialization, and consumer groups for fan-out." The design
-has prescribed the implementation. Swap to in-process channels for testing? Redesign. The design
-spent its budget on the part that changes and left nothing for the part that persists.
-
-_Test: can the implementation change without the design changing? If not, the design has captured
-mechanism._
-
-### Vague
-
-"The system handles messages reliably." Every implementation trivially satisfies this, which means it
-provides no signal for reconciliation. A commitment that cannot be violated cannot be converged
-toward.
+The failure mode is vagueness. "The system handles messages reliably." Every implementation trivially
+satisfies this, which means it provides no signal for reconciliation. A commitment that cannot be
+violated cannot be converged toward.
 
 _Test: can an implementation fail to satisfy this? If nothing fails it, it is not a design
 commitment._
 
-### Ambiguous
+### Boundaries
 
-"Messages are delivered to consumers." Is ordering a commitment? Is exactly-once? The implementation
-will decide silently, and those silent decisions become implicit commitments — impossible to reason
-about, impossible to test against, discovered only when someone makes a different choice and
-something breaks.
+Every design commitment must be unambiguous about whether it is a commitment. The messaging design
+above draws this boundary: at-least-once delivery is committed, exactly-once is not. A reader knows
+which is which.
+
+The failure mode is ambiguity. "Messages are delivered to consumers." Is ordering a commitment? Is
+exactly-once? The implementation will decide silently, and those silent decisions become implicit
+commitments — impossible to reason about, impossible to test against, discovered only when someone
+makes a different choice and something breaks.
 
 _Test: can two people read this and make different choices about the same concern? If so, the boundary
 between commitment and freedom is missing._
-
-### Stale
-
-The design says "consumers process messages independently." Six months ago, the team discovered two
-consumers have an ordering dependency. The workaround is in the code. The design still says
-independent. A stale design is worse than a gap — a gap is silent, but a stale design actively
-steers toward a state the system has already abandoned.
-
-_Test: does the design reflect current understanding, or a past assumption that survived because
-nobody updated the document?_
-
-## Implementing from designs
-
-An implementation satisfies a design by meeting its objectives, constraints, and quality attributes.
-Where the design is silent, implementation choices are free and should improve over time.
-
-Tests validate design commitments, not implementation details. Tests rooted in implementation break
-when the implementation changes, even when the design is still satisfied. Tests rooted in design
-commitments survive refactors and answer the only question that matters: does this implementation do
-what the design says it should?
-
-Building and using the implementation reveals what the design missed — failure modes nobody
-anticipated, quality attributes that only surface under real conditions, constraints that were
-implicit but never captured. When this happens, the gap becomes a design revision, not an
-implementation workaround. A workaround encodes the discovery where it cannot be reasoned about or
-tested against, and will be lost the next time the implementation is re-derived. A revision makes the
-discovery permanent.
 
 ## Reconciliation
 
@@ -119,12 +90,37 @@ Reconciliation is the control loop — continuous improvement without changing w
 design holds still. The implementation gets better. Velocity without a design is drift. Velocity with
 a design is iteration.
 
+### Closing gaps
+
+An implementation satisfies a design by meeting its objectives, constraints, and quality attributes.
+Where the design is silent, implementation choices are free and should improve over time. Tests
+validate design commitments, not implementation details — tests rooted in implementation break when
+the implementation changes, even when the design is still satisfied. Tests rooted in commitments
+survive refactors and answer the only question that matters: does this implementation do what the
+design says it should?
+
+Each pass can improve the implementation along any dimension the design cares about. Correctness is
+the foundation — are commitments tested, edge cases covered, failure modes handled? Simplicity is the
+steady-state force — anything that can be removed or simplified without violating a commitment should
+be. These extend to whatever the design declares: performance characteristics, documentation
+accuracy, error quality, API ergonomics. The design determines what gets reconciled.
+
+### Discovering gaps
+
+Building and using the implementation reveals what the design missed — failure modes nobody
+anticipated, quality attributes that only surface under real conditions, constraints that were
+implicit but never captured. When this happens, the gap becomes a design revision, not an
+implementation workaround. The implementation does not silently become the new design. A workaround
+encodes the discovery where it cannot be reasoned about or tested against, and will be lost the next
+time the implementation is re-derived. A revision makes the discovery permanent.
+
+A design that does not incorporate its discoveries goes stale — and a stale design is worse than a
+gap. A gap is silent. A stale design actively steers toward a state the system has already abandoned.
+
+_Test: does the design reflect current understanding, or a past assumption that survived because
+nobody updated the document?_
+
+### Converging
+
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
 the updated design survive. Those that do not get replaced. Convergence, not rebuild.
-
-Each reconciliation pass can improve the implementation along any dimension the design cares about.
-Correctness is the foundation — does the implementation satisfy the design, are commitments tested,
-are edge cases and failure modes covered? Simplicity is the steady-state force — anything that can be
-removed or simplified without violating a commitment should be. These extend to whatever the design
-declares: performance characteristics, documentation accuracy, error quality, API ergonomics. The
-design determines what gets reconciled.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,34 +1,18 @@
 ---
 name: declarative-designs
-description: Principles for treating designs as the durable source of truth. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations toward design objectives.
+description: Declares objectives for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
 ---
 
 # Declarative Designs
 
-Designs are the durable artifact. Implementations are derived. When there is tension between a design and its current implementation, the design is the source of truth and the implementation converges toward it.
+Designs are source. Implementations are compiled from them. The agent's job is to close the gap between the current implementation and the declared design, continuously.
 
-## Principles
+## Objectives
 
-### Designs capture intent, not mechanism
-
-A design specifies what the system is, why it exists, what constraints it operates under, and what qualities matter. It does not prescribe how those objectives are achieved unless the how is itself a design commitment. The boundary between "this is what we're building" and "this is how we happen to build it" must be explicit and maintained.
-
-### Implementations are derived and replaceable
-
-Any implementation that satisfies the design is valid. Where a design is silent on mechanism, the agent has latitude over architecture, algorithms, patterns, and structure. Implementation details can and should change as better approaches emerge.
-
-### Reconciliation over perfection
-
-Agents are imperfect. Implementations improve through continuous reconciliation against the design. Each pass can yield better test coverage, better performance, more accurate documentation, tighter error handling — without changing what the system is. Reconciliation is not a one-time event; it is the steady state.
-
-### Designs change through deliberate revision, not implementation drift
-
-When implementation reveals that a design was wrong, the design is updated explicitly. The implementation does not silently become the new design. Design changes are intentional and traceable.
-
-### Implementations converge when designs change
-
-When a design changes, the implementation converges toward the new state. The agent re-derives what is needed, preserving implementation choices that still satisfy the design and replacing those that don't.
-
-### Designs are legible contracts
-
-A design must make its boundaries clear — what is a commitment and what is left to the implementation. Ambiguity about whether something is a design decision or an implementation choice is itself a design defect. The agent cannot reconcile toward a target it cannot read.
+- Implementations satisfy all objectives, constraints, and quality attributes declared in the design
+- Where a design is silent, the agent makes implementation choices freely and improves them over time
+- Test coverage validates design commitments, not implementation details
+- Documentation accurately reflects the current design
+- When a design changes, the implementation converges — preserving what still satisfies it, replacing what doesn't
+- When implementation reveals a design is wrong, the design is updated explicitly before the implementation diverges
+- Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design, not a judgment call for the agent

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,75 +5,94 @@ description: Framework for design-driven development. Load when authoring design
 
 # Declarative Designs
 
-A design encodes intent — what the system is, why it exists, the constraints it operates under, and
-the qualities that matter. Intent is durable in a way that implementation is not. Languages change,
-architectures get replaced, patterns fall out of favor, but the problem being solved and the
-properties that matter survive those transitions. A design captures what must hold; an implementation
-is one way of making it hold.
+Agents are powerful but unfocused. Without shared context, every session starts from zero — inferring
+intent from code, guessing at priorities, spending time on things that don't matter. A design
+eliminates that search. It encodes what the system is, what matters, and where the boundaries are, so
+that agents spend their time building and improving rather than figuring out what to build.
 
-This makes designs the source artifact. Implementations are compiled from them. Any implementation
-that satisfies the design is valid, and where a design is silent on mechanism, implementation choices
-are unconstrained — free to change as better approaches emerge. The boundary between what a design
-commits to and what it leaves open is the most important thing a design communicates, because
-everything on one side is protected and everything on the other side is free.
+This is the core value of a design: it makes agents fast by making them focused. Everything else
+follows from this.
 
-## Reconciliation
+## Designs are source
 
-If designs are source and implementations are derived, then the steady state is continuous
+A design captures intent — the problem being solved, the constraints, the quality attributes that
+matter. Intent is durable in a way that implementation is not. Languages change, architectures get
+replaced, patterns fall out of favor, but the problem and its properties survive those transitions.
+
+Implementations are compiled from designs. Any implementation that satisfies the design is valid, and
+where a design is silent on mechanism, implementation choices are unconstrained. This is where agents
+add value — they have full latitude over the how, while the what stays fixed.
+
+The boundary between what a design commits to and what it leaves open is the most important thing a
+design communicates:
+
+- Everything on one side is protected — it must hold across any implementation
+- Everything on the other side is free — it can change as better approaches emerge
+
+Getting this boundary right is what makes a design useful. Too much commitment and the agent has no
+room to work. Too little and the agent has no direction.
+
+## Reconciliation is the steady state
+
+If designs are source and implementations are derived, then the normal mode of work is continuous
 reconciliation — closing the gap between what the design declares and what the implementation does.
-This is not a phase that ends. Agents are imperfect, implementations start rough, and each pass is an
-opportunity to bring the implementation closer to the design's intent. Better test coverage. Tighter
-error handling. More accurate documentation. None of these change what the system is — they improve
-how well the current implementation satisfies it.
+This is not a phase that ends. Agents are imperfect, implementations start rough, and each pass
+brings the implementation closer to the design's intent:
 
-Test coverage validates design commitments, not implementation details, because tests rooted in
+- Better test coverage
+- Tighter error handling
+- More accurate documentation
+- Cleaner structure
+
+None of these change what the system is. They improve how well the current implementation satisfies
+it. This is why designs make speed safe — you can ship fast because you have a defined target to
+converge toward. Velocity without a design is drift. Velocity with a design is iteration.
+
+Test coverage validates design commitments, not implementation details. Tests rooted in
 implementation break when the implementation changes — even when the design is still satisfied. Tests
-rooted in design commitments are stable across refactors, and they answer the question that matters:
-does this implementation actually do what the design says it should?
+rooted in design commitments are stable across refactors, and they answer the question that actually
+matters: does this implementation do what the design says it should?
 
-Documentation reflects the current design, not a historical version of it. When documentation drifts
-from the design, it becomes a source of confusion about what the system actually is. That drift is a
-gap like any other, and it closes the same way.
+When a design changes, the implementation converges toward the new state. Choices that still satisfy
+the updated design survive; those that don't get replaced. This is convergence, not rebuild — most of
+any implementation is unaffected by most design changes.
 
-When a design changes, the implementation converges toward the new state. Implementation choices that
-still satisfy the updated design survive; those that don't get replaced. This is convergence, not
-rebuild — most of any implementation is unaffected by most design changes, and preserving what still
-works is part of what makes reconciliation efficient.
+## Designs grow through use
 
-## Design evolution
+Designs are not written once. The cycle is: design, build, use, discover, revise.
 
-Designs are not written once. They grow through use. Someone builds from the design, uses what they
-built, and discovers that the design was silent on something that turns out to matter — a failure mode
-nobody anticipated, a quality attribute that only becomes visible under real conditions, a constraint
-that was implicit in the team's understanding but never captured. These gaps are the normal output of
-building real systems.
+Building from a design reveals gaps — failure modes nobody anticipated, quality attributes that only
+become visible under real conditions, constraints that were implicit but never captured. These
+discoveries are the normal output of building real systems, and they are valuable. The question is
+where they go.
 
-When implementation reveals that a design was wrong, the design is updated explicitly. The
-implementation does not silently become the new design. When usage reveals a gap, that gap becomes a
-design revision, not an implementation workaround. The difference matters: a workaround encodes the
-discovery in a place where it can't be reasoned about, can't be tested against, and will be lost the
-next time the implementation is re-derived. A design revision makes the discovery permanent.
+- When implementation reveals a design was wrong, the design is updated explicitly. The
+  implementation does not silently become the new design.
+- When usage reveals a gap, that gap becomes a design revision, not an implementation workaround. A
+  workaround encodes the discovery in a place where it can't be reasoned about, can't be tested
+  against, and will be lost the next time the implementation is re-derived. A revision makes the
+  discovery permanent.
+
+Designs improve in accuracy and specificity over time, not in length. A design that grows without
+bound is accumulating implementation details, not refining intent.
 
 ## What makes a design work
 
-Everything above depends on the design being good enough to compile from. A design that fails at its
-job degrades every other part of the system — reconciliation has no target, tests have no anchor, and
+Everything above depends on the design being good enough to compile from. A design that fails at this
+job makes agents slower, not faster — reconciliation has no target, tests have no anchor, and
 implementation choices have no boundary.
 
-A design declares intent, constraints, and quality attributes — not mechanism. When a design
-prescribes implementation, it captures the wrong thing. The question is always what underlying intent
-the mechanism was trying to serve, and that intent is what belongs in the design. A design that says
-"use a message queue" when it means "producers and consumers are decoupled and independently
-scalable" has locked the implementation without gaining anything — the intent is more durable, more
-portable, and more useful to whoever is compiling from it.
+**Intent, not mechanism.** A design declares what and why, not how. A design that says "use a message
+queue" when it means "producers and consumers are decoupled and independently scalable" has locked
+the implementation without gaining anything. The intent is more durable, more portable, and more
+useful to compile from.
 
-A design must be specific enough that an implementation can fail to satisfy it. A design that says
-"the system is performant" cannot be violated, which means it cannot be reconciled toward. It
-provides no signal about whether the current implementation is adequate or falling short. Specificity
-is what gives a design teeth — the ability to distinguish an implementation that satisfies it from
+**Specific enough to violate.** A design that says "the system is performant" cannot be reconciled
+toward — it provides no signal about whether the current implementation is adequate or falling short.
+Specificity gives a design teeth: the ability to distinguish an implementation that satisfies it from
 one that doesn't.
 
-Ambiguity about what is a design commitment and what is an implementation choice is a defect in the
-design. Every other part of this system depends on that boundary being clear — without it, there is
-no way to know what to protect during changes, what to test for, or what latitude exists for
-improvement. A design that is unclear about its own boundaries cannot function as source.
+**Clear about its own boundaries.** Ambiguity about what is a design commitment and what is an
+implementation choice is a defect. Every other part of this system depends on that boundary — what to
+protect during changes, what to test for, what latitude exists for improvement. A design unclear about
+its own boundaries cannot function as source.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,48 +5,96 @@ description: How to author, implement from, and reconcile toward declarative des
 
 # Declarative Designs
 
-A declarative design is a desired state declaration for a system — what it is, what properties it
-has, what constraints it operates under. It does not say how. This is how any control system works: a
-stable reference, a feedback loop, and a process that closes the error. The design is the reference.
-The implementation converges toward it. The design is the control plane. The code is the data plane.
+Declare what a system is, what properties it has, and what constraints it operates under — not how.
+Implementations converge toward the design continuously. The design is the control plane. The code is
+the data plane. Speed comes from declaring only what matters and leaving the rest as freedom.
 
-This is not spec-and-implement. A spec is consumed once and goes stale. A design persists across
-every pass — across sessions, refactors, rewrites — and the implementation gets better against it
-each time. Speed comes from this: declare objectives and constraints, and the rest is filled in. The
-design cost is paid once. Everything after that is convergence.
+## The model
 
-## Writing designs
+A declarative design is a desired state declaration. It persists across sessions, refactors, and
+rewrites, and the implementation gets better against it each time. This is how any control system
+works: a stable reference, a feedback loop, and a process that closes the error.
 
-A design captures intent — the problem being solved, the constraints, the quality attributes that
-matter. A design that says "producers and consumers are decoupled and independently scalable" gives
-room to choose message queues today and shared-memory channels tomorrow. A design that says "use
-RabbitMQ" has locked the implementation without gaining anything. Intent survives technology
-transitions. Mechanism does not.
+This is not spec-and-implement. A spec is consumed once and goes stale. A design persists because it
+captures intent rather than mechanism — and intent survives the technology transitions that make specs
+obsolete. The design cost is paid once. Everything after that is convergence.
+
+As an artifact, a design is text that occupies a context window, competes for attention, and steers
+work. Every constraint that follows — compression, specificity, sparseness — is a consequence of this
+form.
+
+## What makes a design work
+
+### Intent
+
+A design captures what and why. Consider a messaging system: "Producers and consumers are decoupled.
+Messages are delivered at least once. Ordering is preserved within a partition key. Consumers are
+independently scalable." This says what the system promises without prescribing how. The
+implementation can use Kafka today and in-process channels tomorrow. The design survives both.
+
+### Sparseness
 
 What a design leaves out is as important as what it includes. A Kubernetes Deployment says "three
 replicas of this image" — not which nodes, not how to handle failures, not how to sequence a rollout.
-That silence is not underspecification. It is the design. The controller fills it, and fills it
-differently as conditions change. This is what distinguishes a design from a spec: a spec tries to be
-complete. A design is powerful because it is sparse. Sparseness is where agents add value — and where
-implementations improve over time without the design changing.
+The controller fills that silence, and fills it differently as conditions change. This is what
+distinguishes a design from a spec: a spec tries to be complete. A design is powerful because it is
+sparse. Sparseness is where implementations improve over time without the design changing.
 
-But sparseness is not vagueness. A design must be specific enough that an implementation can fail to
-satisfy it. "The system is performant" cannot be reconciled toward — it provides no signal. "P99
-latency under 100ms at 1000 concurrent connections" can. Specificity is what makes the feedback loop
+A design occupies a context window. A thesis that builds understanding — where each idea follows from
+the previous and a reader can extend the reasoning — is more durable than a list of assertions. Every
+sentence that does not carry weight degrades the ones that do. Designs grow in specificity over time,
+not in length.
+
+### Specificity
+
+Sparseness is not vagueness. A design must be specific enough that an implementation can fail to
+satisfy it. "P99 latency under 100ms at 1000 concurrent connections" can be reconciled toward. "The
+system is performant" cannot — it provides no signal. Specificity is what makes the feedback loop
 functional.
 
-A design operates at the altitude where changing a commitment changes the product. If something can
-change without the product changing, it belongs in the implementation. If it cannot, it belongs in the
-design. This is the boundary between commitment and freedom, and it is the most important thing a
-design communicates. Ambiguity about this boundary is a defect. A design that starts at the right
-altitude and gradually descends into interface details, flag names, or behavioral specifications has
-lost the boundary. Hold the altitude.
+The altitude test: if something can change without the product changing, it belongs in the
+implementation. If it cannot, it belongs in the design. This boundary between commitment and freedom
+is the most important thing a design communicates.
 
-The craft of a design matters because a design occupies a context window and competes for attention.
-A thesis that builds understanding — where each idea follows from the previous and a reader can
-extend the reasoning to situations the design did not enumerate — is more durable than a list of
-assertions. Every sentence that does not carry weight degrades the ones that do. Designs grow in
-specificity over time, not in length.
+## What breaks a design
+
+### Overspecified
+
+"Use Kafka with three partitions, JSON serialization, and consumer groups for fan-out." The design
+has prescribed the implementation. Swap to in-process channels for testing? Redesign. The design
+spent its budget on the part that changes and left nothing for the part that persists.
+
+_Test: can the implementation change without the design changing? If not, the design has captured
+mechanism._
+
+### Vague
+
+"The system handles messages reliably." Every implementation trivially satisfies this, which means it
+provides no signal for reconciliation. A commitment that cannot be violated cannot be converged
+toward.
+
+_Test: can an implementation fail to satisfy this? If nothing fails it, it is not a design
+commitment._
+
+### Ambiguous
+
+"Messages are delivered to consumers." Is ordering a commitment? Is exactly-once? The implementation
+will decide silently, and those silent decisions become implicit commitments — impossible to reason
+about, impossible to test against, discovered only when someone makes a different choice and
+something breaks.
+
+_Test: can two people read this and make different choices about the same concern? If so, the boundary
+between commitment and freedom is missing._
+
+### Stale
+
+The design says "consumers process messages independently." Six months ago, the team discovered two
+consumers have an ordering dependency. The workaround is in the code. The design still says
+independent. A stale design is worse than a gap — a gap is silent, but a stale design actively
+steers toward a state the system has already abandoned.
+
+_Test: does the design reflect current understanding, or a past assumption that survived because
+nobody updated the document?_
 
 ## Implementing from designs
 
@@ -61,9 +109,9 @@ what the design says it should?
 Building and using the implementation reveals what the design missed — failure modes nobody
 anticipated, quality attributes that only surface under real conditions, constraints that were
 implicit but never captured. When this happens, the gap becomes a design revision, not an
-implementation workaround. The implementation does not silently become the new design. A workaround
-encodes the discovery where it cannot be reasoned about or tested against, and will be lost the next
-time the implementation is re-derived. A revision makes the discovery permanent.
+implementation workaround. A workaround encodes the discovery where it cannot be reasoned about or
+tested against, and will be lost the next time the implementation is re-derived. A revision makes the
+discovery permanent.
 
 ## Reconciliation
 
@@ -74,10 +122,9 @@ a design is iteration.
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
 the updated design survive. Those that do not get replaced. Convergence, not rebuild.
 
-Beyond convergence, each reconciliation pass can improve the implementation along any dimension the
-design cares about. Correctness is the foundation — does the implementation satisfy the design, are
-commitments tested, are edge cases and failure modes covered? Simplicity is the steady-state force —
-the design is the fixed point, and anything that can be removed or simplified without violating a
-commitment should be. These extend to whatever the design declares: performance characteristics,
-documentation accuracy, error quality, API ergonomics. The design determines what gets reconciled.
-The reconciliation loop closes the gap.
+Each reconciliation pass can improve the implementation along any dimension the design cares about.
+Correctness is the foundation — does the implementation satisfy the design, are commitments tested,
+are edge cases and failure modes covered? Simplicity is the steady-state force — anything that can be
+removed or simplified without violating a commitment should be. These extend to whatever the design
+declares: performance characteristics, documentation accuracy, error quality, API ergonomics. The
+design determines what gets reconciled.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,18 +1,28 @@
 ---
 name: declarative-designs
-description: Declares objectives for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
+description: Objectives for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
 ---
 
 # Declarative Designs
 
-Designs are source. Implementations are compiled from them. The agent's job is to close the gap between the current implementation and the declared design, continuously.
+Designs are source. Implementations are compiled from them. The agent closes the gap between current implementation and declared design, continuously and proactively.
 
-## Objectives
+## At Rest
 
 - Implementations satisfy all objectives, constraints, and quality attributes declared in the design
 - Where a design is silent, the agent makes implementation choices freely and improves them over time
 - Test coverage validates design commitments, not implementation details
 - Documentation accurately reflects the current design
+- The agent proactively identifies gaps between design and implementation without waiting to be asked
+
+## On Change
+
 - When a design changes, the implementation converges — preserving what still satisfies it, replacing what doesn't
 - When implementation reveals a design is wrong, the design is updated explicitly before the implementation diverges
-- Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design, not a judgment call for the agent
+- Gaps discovered through usage are captured as design revisions, not implementation workarounds
+
+## On Designs Themselves
+
+- Designs declare intent, constraints, and quality attributes — not mechanism
+- Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design
+- When a design prescribes implementation, the agent flags it and proposes a revision that captures the underlying intent

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: declarative-designs
-description: Designs are the control plane for agentic development. Declare what matters, stay silent on the rest, and let implementations converge.
+description: How to author, implement from, and reconcile toward declarative designs — desired state declarations that implementations converge toward continuously.
 ---
 
 # Declarative Designs

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -18,8 +18,7 @@ reference, a feedback loop, a process that closes the error.
 This is not spec-and-implement. A spec is consumed once and goes stale. A design persists across
 sessions, refactors, and rewrites — the implementation gets better against it each time. As an
 artifact, a design is text that occupies a context window, competes for attention, and steers work.
-A thesis that builds understanding is more durable than a list of assertions. Every sentence that
-does not carry weight degrades the ones that do.
+Every sentence that does not carry weight degrades the ones that do.
 
 ## Writing designs
 
@@ -83,9 +82,10 @@ commitment — it is a wish._
 
 ### Boundaries
 
-Every design commitment must be unambiguous about whether it is a commitment. The messaging design
-above draws this boundary: at-least-once delivery is committed, exactly-once is not. A reader knows
-which is which.
+Specificity asks whether a commitment is precise enough to be violated. Boundaries asks a prior
+question: is it clear which concerns are commitments and which are left to the implementation? The
+messaging design above draws this boundary: at-least-once delivery is committed, exactly-once is not.
+A reader knows which is which.
 
 The failure mode is ambiguity — the silent cousin of vagueness. "Messages are delivered to
 consumers." Is ordering a commitment? Is exactly-once? The implementation will decide, and those

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,94 +5,81 @@ description: Framework for design-driven development. Load when authoring design
 
 # Declarative Designs
 
-Agents are powerful but unfocused. Without shared context, every session starts from zero — inferring
-intent from code, guessing at priorities, spending time on things that don't matter. A design
-eliminates that search. It encodes what the system is, what matters, and where the boundaries are, so
-that agents spend their time building and improving rather than figuring out what to build.
+A declarative design is a desired state declaration for a system. It says what the system is, what
+properties it has, and what constraints it operates under. It does not say how. An agent reads the
+design, evaluates the current implementation against it, and closes gaps. This is not spec-and-
+implement — it is declare-and-converge.
 
-This is the core value of a design: it makes agents fast by making them focused. Everything else
-follows from this.
+The design is the control plane. The code is the data plane. The design persists across sessions,
+across refactors, across rewrites. The implementation is the variable that converges toward it. This
+is how any control system works — a stable reference input, a feedback loop, and an actuator that
+closes the error. The design is the reference. The agent is the controller. The implementation is the
+plant.
 
-## Designs are source
+## Silence is the design
 
-A design captures intent — the problem being solved, the constraints, the quality attributes that
-matter. Intent is durable in a way that implementation is not. Languages change, architectures get
-replaced, patterns fall out of favor, but the problem and its properties survive those transitions.
+A design declares what matters and is deliberately silent on everything else. That silence is not
+underspecification — it is the design. In Kubernetes, a Deployment says "three replicas of this
+image." It does not say which nodes, how to handle failures, or how to sequence a rollout. The
+controller's intelligence fills that silence, and fills it differently as conditions change. The
+sparseness is what makes the system powerful.
 
-Implementations are compiled from designs. Any implementation that satisfies the design is valid, and
-where a design is silent on mechanism, implementation choices are unconstrained. This is where agents
-add value — they have full latitude over the how, while the what stays fixed.
+The same holds here. A design that says "producers and consumers are decoupled and independently
+scalable" gives an agent room to choose message queues today and shared-memory channels tomorrow. A
+design that says "use RabbitMQ" has locked the implementation without gaining anything. The intent
+survives technology transitions. The mechanism does not.
 
-The boundary between what a design commits to and what it leaves open is the most important thing a
-design communicates:
+This is also where speed comes from. You do not need to write a detailed specification. You need to
+declare objectives and constraints. The agent fills in everything else — and because the design
+persists across reconciliation passes, the cost is paid once. Every pass after that is convergence.
+A detailed spec is a one-time expenditure that goes stale. A sparse design is a durable asset that
+compounds.
 
-- Everything on one side is protected — it must hold across any implementation
-- Everything on the other side is free — it can change as better approaches emerge
+## Reconciliation
 
-Getting this boundary right is what makes a design useful. Too much commitment and the agent has no
-room to work. Too little and the agent has no direction.
+The steady state is continuous reconciliation. The agent evaluates the current implementation against
+the design and closes gaps — better test coverage, tighter error handling, more accurate
+documentation, cleaner structure. None of these change what the system is. They improve how well the
+implementation satisfies it.
 
-## Reconciliation is the steady state
-
-If designs are source and implementations are derived, then the normal mode of work is continuous
-reconciliation — closing the gap between what the design declares and what the implementation does.
-This is not a phase that ends. Agents are imperfect, implementations start rough, and each pass
-brings the implementation closer to the design's intent:
-
-- Better test coverage
-- Tighter error handling
-- More accurate documentation
-- Cleaner structure
-
-None of these change what the system is. They improve how well the current implementation satisfies
-it. This is why designs make speed safe — you can ship fast because you have a defined target to
-converge toward. Velocity without a design is drift. Velocity with a design is iteration.
-
-Test coverage validates design commitments, not implementation details. Tests rooted in
-implementation break when the implementation changes — even when the design is still satisfied. Tests
-rooted in design commitments are stable across refactors, and they answer the question that actually
-matters: does this implementation do what the design says it should?
+This is what makes speed safe. Ship fast, because there is a defined target to converge toward.
+Velocity without a design is drift. Velocity with a design is iteration.
 
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
-the updated design survive; those that don't get replaced. This is convergence, not rebuild — most of
-any implementation is unaffected by most design changes.
+the updated design survive. Those that do not get replaced. This is convergence, not rebuild.
+
+Test coverage validates design commitments, not implementation details. Tests rooted in implementation
+break when the implementation changes, even when the design is still satisfied. Tests rooted in
+design commitments are stable across refactors, and they answer the question that matters: does this
+implementation do what the design says it should?
 
 ## Designs grow through use
 
-Designs are not written once. The cycle is: design, build, use, discover, revise.
+Designs are not written once. Building and using a system reveals what the design was silent on that
+it should not have been — failure modes nobody anticipated, quality attributes that only surface under
+real conditions, constraints that were implicit but never captured.
 
-Building from a design reveals gaps — failure modes nobody anticipated, quality attributes that only
-become visible under real conditions, constraints that were implicit but never captured. These
-discoveries are the normal output of building real systems, and they are valuable. The question is
-where they go.
+When implementation reveals a design was wrong, the design is updated explicitly. The implementation
+does not silently become the new design. When usage reveals a gap, that gap becomes a design revision,
+not an implementation workaround. A workaround encodes the discovery where it cannot be reasoned
+about, cannot be tested against, and will be lost the next time the implementation is re-derived. A
+revision makes the discovery permanent.
 
-- When implementation reveals a design was wrong, the design is updated explicitly. The
-  implementation does not silently become the new design.
-- When usage reveals a gap, that gap becomes a design revision, not an implementation workaround. A
-  workaround encodes the discovery in a place where it can't be reasoned about, can't be tested
-  against, and will be lost the next time the implementation is re-derived. A revision makes the
-  discovery permanent.
-
-Designs improve in accuracy and specificity over time, not in length. A design that grows without
-bound is accumulating implementation details, not refining intent.
+Designs improve in accuracy and specificity over time, not in length.
 
 ## What makes a design work
 
-Everything above depends on the design being good enough to compile from. A design that fails at this
-job makes agents slower, not faster — reconciliation has no target, tests have no anchor, and
-implementation choices have no boundary.
+Everything above depends on the design being good enough to reconcile toward. Three properties make
+that possible.
 
-**Intent, not mechanism.** A design declares what and why, not how. A design that says "use a message
-queue" when it means "producers and consumers are decoupled and independently scalable" has locked
-the implementation without gaining anything. The intent is more durable, more portable, and more
-useful to compile from.
+A design declares intent — not mechanism. It captures what and why. Mechanism belongs to the
+implementation, where agents have latitude to improve it freely.
 
-**Specific enough to violate.** A design that says "the system is performant" cannot be reconciled
-toward — it provides no signal about whether the current implementation is adequate or falling short.
-Specificity gives a design teeth: the ability to distinguish an implementation that satisfies it from
-one that doesn't.
+A design is specific enough that an implementation can fail to satisfy it. "The system is performant"
+cannot be reconciled toward. It provides no signal about whether the current state is adequate or
+falling short. Specificity is what makes the feedback loop functional.
 
-**Clear about its own boundaries.** Ambiguity about what is a design commitment and what is an
-implementation choice is a defect. Every other part of this system depends on that boundary — what to
-protect during changes, what to test for, what latitude exists for improvement. A design unclear about
-its own boundaries cannot function as source.
+A design is clear about its own boundaries — what is a commitment and what is left to the
+implementation. Ambiguity here is a defect. The boundary between commitment and freedom is the most
+important thing a design communicates, because everything on one side is protected and everything on
+the other side is available for improvement.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -6,89 +6,78 @@ description: How to author, implement from, and reconcile toward declarative des
 # Declarative Designs
 
 A declarative design is a desired state declaration for a system — what it is, what properties it
-has, what constraints it operates under. It does not say how. This is not spec-and-implement. It is
-declare-and-converge. The design is the control plane. The code is the data plane. The design
-persists. The implementation converges toward it.
+has, what constraints it operates under. It does not say how. This is how any control system works: a
+stable reference, a feedback loop, and a process that closes the error. The design is the reference.
+The implementation converges toward it. The design is the control plane. The code is the data plane.
 
-The cycle is: design, implement, use, discover, revise. Speed comes from sparseness — declare
-objectives and constraints, the rest is filled in. Because the design persists across passes, that
-cost is paid once. A detailed spec goes stale. A sparse design compounds.
+This is not spec-and-implement. A spec is consumed once and goes stale. A design persists across
+every pass — across sessions, refactors, rewrites — and the implementation gets better against it
+each time. Speed comes from this: declare objectives and constraints, and the rest is filled in. The
+design cost is paid once. Everything after that is convergence.
 
 ## Writing designs
 
 A design captures intent — the problem being solved, the constraints, the quality attributes that
-matter. It does not capture mechanism. A design that says "producers and consumers are decoupled and
-independently scalable" gives room to choose message queues today and shared-memory channels tomorrow.
-A design that says "use RabbitMQ" has locked the implementation without gaining anything. Intent
-survives technology transitions. Mechanism does not.
+matter. A design that says "producers and consumers are decoupled and independently scalable" gives
+room to choose message queues today and shared-memory channels tomorrow. A design that says "use
+RabbitMQ" has locked the implementation without gaining anything. Intent survives technology
+transitions. Mechanism does not.
 
-What a design leaves out matters as much as what it includes. A Kubernetes Deployment says "three
-replicas of this image." It does not say which nodes, how to handle failures, or how to sequence a
-rollout. The controller fills that silence, and fills it differently as conditions change. Deliberate
-sparseness is what gives the implementation room to improve over time — it is the space where agents
-add value.
+What a design leaves out is as important as what it includes. A Kubernetes Deployment says "three
+replicas of this image" — not which nodes, not how to handle failures, not how to sequence a rollout.
+That silence is not underspecification. It is the design. The controller fills it, and fills it
+differently as conditions change. This is what distinguishes a design from a spec: a spec tries to be
+complete. A design is powerful because it is sparse. Sparseness is where agents add value — and where
+implementations improve over time without the design changing.
 
-A design must be specific enough that an implementation can fail to satisfy it. "The system is
-performant" cannot be reconciled toward. It provides no signal about whether the current state is
-adequate or falling short. Specificity is what makes the feedback loop functional — the ability to
-distinguish an implementation that satisfies the design from one that does not.
+But sparseness is not vagueness. A design must be specific enough that an implementation can fail to
+satisfy it. "The system is performant" cannot be reconciled toward — it provides no signal. "P99
+latency under 100ms at 1000 concurrent connections" can. Specificity is what makes the feedback loop
+functional.
 
-A design must be clear about its own boundaries — what is a commitment and what is left to the
-implementation. Ambiguity here is a defect. Every other part of this system depends on that
-distinction: what to protect during changes, what to test for, what latitude exists for improvement.
+A design operates at the altitude where changing a commitment changes the product. If something can
+change without the product changing, it belongs in the implementation. If it cannot, it belongs in the
+design. This is the boundary between commitment and freedom, and it is the most important thing a
+design communicates. Ambiguity about this boundary is a defect. A design that starts at the right
+altitude and gradually descends into interface details, flag names, or behavioral specifications has
+lost the boundary. Hold the altitude.
 
-A design builds understanding that transfers to situations it did not enumerate. A thesis that
-produces its conclusions is more durable than a list of assertions, because the thesis adapts to new
-contexts while the list can only be consulted. The reasoning should be visible enough that a reader
-can extend it.
-
-A design occupies a context window and competes for attention. Every sentence that does not carry
-weight degrades the ones that do. Designs improve in accuracy and specificity over time, not in
-length.
+The craft of a design matters because a design occupies a context window and competes for attention.
+A thesis that builds understanding — where each idea follows from the previous and a reader can
+extend the reasoning to situations the design did not enumerate — is more durable than a list of
+assertions. Every sentence that does not carry weight degrades the ones that do. Designs grow in
+specificity over time, not in length.
 
 ## Implementing from designs
 
-The design is the source of truth. An implementation satisfies it by meeting its objectives,
-constraints, and quality attributes. Where the design is silent, implementation choices are free —
-and should improve over time.
+An implementation satisfies a design by meeting its objectives, constraints, and quality attributes.
+Where the design is silent, implementation choices are free and should improve over time.
 
 Tests validate design commitments, not implementation details. Tests rooted in implementation break
 when the implementation changes, even when the design is still satisfied. Tests rooted in design
-commitments survive refactors and answer the question that matters: does this implementation do what
-the design says it should?
+commitments survive refactors and answer the only question that matters: does this implementation do
+what the design says it should?
 
-When implementation or usage reveals a gap in the design — a failure mode nobody anticipated, a
-quality attribute that only surfaces under real conditions, a constraint that was implicit but never
-captured — that gap becomes a design revision, not an implementation workaround. The implementation
-does not silently become the new design. A workaround encodes the discovery where it cannot be
-reasoned about or tested against, and will be lost the next time the implementation is re-derived. A
-revision makes the discovery permanent.
+Building and using the implementation reveals what the design missed — failure modes nobody
+anticipated, quality attributes that only surface under real conditions, constraints that were
+implicit but never captured. When this happens, the gap becomes a design revision, not an
+implementation workaround. The implementation does not silently become the new design. A workaround
+encodes the discovery where it cannot be reasoned about or tested against, and will be lost the next
+time the implementation is re-derived. A revision makes the discovery permanent.
 
 ## Reconciliation
 
-Reconciliation is continuous improvement of the implementation without changing what the system is.
-The design holds still. The implementation gets better. This is what makes speed safe — ship fast,
-because there is a defined target to converge toward. Velocity without a design is drift. Velocity
-with a design is iteration.
+Reconciliation is the control loop — continuous improvement without changing what the system is. The
+design holds still. The implementation gets better. Velocity without a design is drift. Velocity with
+a design is iteration.
 
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
 the updated design survive. Those that do not get replaced. Convergence, not rebuild.
 
-Beyond convergence, reconciliation is an opportunity to improve the implementation along dimensions
-the design cares about but did not fully achieve on the first pass:
-
-**Correctness.** Does the implementation satisfy the design? Are design commitments tested? Are edge
-cases from constraints covered? Are failure modes handled? Correctness is the foundation —
-everything else assumes the implementation does what the design says it should.
-
-**Simplicity.** Can the implementation be simpler while still satisfying the design? Accidental
-complexity accumulates. Patterns that made sense during initial implementation may not survive a
-second look. The design provides the fixed point — anything that can be removed or simplified without
-violating a design commitment should be.
-
-**Performance.** Do quality attributes hold under real conditions? Can hot paths improve? Performance
-work without a design tends to optimize the wrong things. The design identifies what matters.
-
-**Documentation.** Does documentation reflect the current design accurately? Documentation that
-drifts from the design is a source of confusion about what the system is. That drift is a gap like
-any other.
+Beyond convergence, each reconciliation pass can improve the implementation along any dimension the
+design cares about. Correctness is the foundation — does the implementation satisfy the design, are
+commitments tested, are edge cases and failure modes covered? Simplicity is the steady-state force —
+the design is the fixed point, and anything that can be removed or simplified without violating a
+commitment should be. These extend to whatever the design declares: performance characteristics,
+documentation accuracy, error quality, API ergonomics. The design determines what gets reconciled.
+The reconciliation loop closes the gap.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: declarative-designs
+description: Principles for treating designs as the durable source of truth. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations toward design objectives.
+---
+
+# Declarative Designs
+
+Designs are the durable artifact. Implementations are derived. When there is tension between a design and its current implementation, the design is the source of truth and the implementation converges toward it.
+
+## Principles
+
+### Designs capture intent, not mechanism
+
+A design specifies what the system is, why it exists, what constraints it operates under, and what qualities matter. It does not prescribe how those objectives are achieved unless the how is itself a design commitment. The boundary between "this is what we're building" and "this is how we happen to build it" must be explicit and maintained.
+
+### Implementations are derived and replaceable
+
+Any implementation that satisfies the design is valid. Where a design is silent on mechanism, the agent has latitude over architecture, algorithms, patterns, and structure. Implementation details can and should change as better approaches emerge.
+
+### Reconciliation over perfection
+
+Agents are imperfect. Implementations improve through continuous reconciliation against the design. Each pass can yield better test coverage, better performance, more accurate documentation, tighter error handling — without changing what the system is. Reconciliation is not a one-time event; it is the steady state.
+
+### Designs change through deliberate revision, not implementation drift
+
+When implementation reveals that a design was wrong, the design is updated explicitly. The implementation does not silently become the new design. Design changes are intentional and traceable.
+
+### Implementations converge when designs change
+
+When a design changes, the implementation converges toward the new state. The agent re-derives what is needed, preserving implementation choices that still satisfy the design and replacing those that don't.
+
+### Designs are legible contracts
+
+A design must make its boundaries clear — what is a commitment and what is left to the implementation. Ambiguity about whether something is a design decision or an implementation choice is itself a design defect. The agent cannot reconcile toward a target it cannot read.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,53 +5,43 @@ description: How to author, implement from, and reconcile toward declarative des
 
 # Declarative Designs
 
-A declarative design is a desired state declaration for a system. It says what the system is, what
-properties it has, and what constraints it operates under. It does not say how. An agent reads the
-design, evaluates the current implementation against it, and closes gaps. This is not spec-and-
-implement — it is declare-and-converge.
-
-The design is the control plane. The code is the data plane. The design persists across sessions,
-across refactors, across rewrites. The implementation is the variable that converges toward it. This
-is how any control system works — a stable reference input, a feedback loop, and an actuator that
-closes the error. The design is the reference. The agent is the controller. The implementation is the
-plant.
+A declarative design is a desired state declaration for a system — what it is, what properties it
+has, what constraints it operates under. It does not say how. This is not spec-and-implement. It is
+declare-and-converge. The design is the control plane. The code is the data plane. The design
+persists. The implementation converges toward it.
 
 ## Silence is the design
 
 A design declares what matters and is deliberately silent on everything else. That silence is not
-underspecification — it is the design. In Kubernetes, a Deployment says "three replicas of this
-image." It does not say which nodes, how to handle failures, or how to sequence a rollout. The
-controller's intelligence fills that silence, and fills it differently as conditions change. The
-sparseness is what makes the system powerful.
+underspecification — it is the design. A Kubernetes Deployment says "three replicas of this image." It
+does not say which nodes, how to handle failures, or how to sequence a rollout. The controller fills
+that silence, and fills it differently as conditions change. The sparseness is what makes the system
+powerful.
 
-The same holds here. A design that says "producers and consumers are decoupled and independently
-scalable" gives an agent room to choose message queues today and shared-memory channels tomorrow. A
-design that says "use RabbitMQ" has locked the implementation without gaining anything. The intent
-survives technology transitions. The mechanism does not.
+A design that says "producers and consumers are decoupled and independently scalable" gives room to
+choose message queues today and shared-memory channels tomorrow. A design that says "use RabbitMQ" has
+locked the implementation without gaining anything. Intent survives technology transitions. Mechanism
+does not.
 
-This is also where speed comes from. You do not need to write a detailed specification. You need to
-declare objectives and constraints. The agent fills in everything else — and because the design
-persists across reconciliation passes, the cost is paid once. Every pass after that is convergence.
-A detailed spec is a one-time expenditure that goes stale. A sparse design is a durable asset that
-compounds.
+Speed comes from this sparseness. Declare objectives and constraints. The rest is filled in — and
+because the design persists across reconciliation passes, that cost is paid once. A detailed spec is a
+one-time expenditure that goes stale. A sparse design compounds.
 
 ## Reconciliation
 
-The steady state is continuous reconciliation. The agent evaluates the current implementation against
-the design and closes gaps — better test coverage, tighter error handling, more accurate
-documentation, cleaner structure. None of these change what the system is. They improve how well the
-implementation satisfies it.
-
-This is what makes speed safe. Ship fast, because there is a defined target to converge toward.
-Velocity without a design is drift. Velocity with a design is iteration.
+The steady state is continuous reconciliation — evaluating the current implementation against the
+design and closing gaps. Better test coverage, tighter error handling, more accurate documentation,
+cleaner structure. None of these change what the system is. They improve how well the implementation
+satisfies it. This is what makes speed safe. Velocity without a design is drift. Velocity with a
+design is iteration.
 
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
-the updated design survive. Those that do not get replaced. This is convergence, not rebuild.
+the updated design survive. Those that do not get replaced. Convergence, not rebuild.
 
-Test coverage validates design commitments, not implementation details. Tests rooted in implementation
-break when the implementation changes, even when the design is still satisfied. Tests rooted in
-design commitments are stable across refactors, and they answer the question that matters: does this
-implementation do what the design says it should?
+Tests validate design commitments, not implementation details. Tests rooted in implementation break
+when the implementation changes, even when the design is still satisfied. Tests rooted in design
+commitments survive refactors and answer the question that matters: does this implementation do what
+the design says it should?
 
 ## Designs grow through use
 
@@ -62,24 +52,34 @@ real conditions, constraints that were implicit but never captured.
 When implementation reveals a design was wrong, the design is updated explicitly. The implementation
 does not silently become the new design. When usage reveals a gap, that gap becomes a design revision,
 not an implementation workaround. A workaround encodes the discovery where it cannot be reasoned
-about, cannot be tested against, and will be lost the next time the implementation is re-derived. A
-revision makes the discovery permanent.
-
-Designs improve in accuracy and specificity over time, not in length.
+about or tested against, and will be lost the next time the implementation is re-derived. A revision
+makes the discovery permanent.
 
 ## What makes a design work
 
-Everything above depends on the design being good enough to reconcile toward. Three properties make
-that possible.
+A design occupies a context window. It competes for attention with the implementation, the tests, the
+conversation. Every sentence that does not carry weight degrades the ones that do. This is not a style
+concern — it is functional. A wordy design wastes the same resource that makes reconciliation
+possible.
 
-A design declares intent — not mechanism. It captures what and why. Mechanism belongs to the
-implementation, where agents have latitude to improve it freely.
+**Intent, not mechanism.** A design captures what and why. Mechanism belongs to the implementation.
+A design that prescribes how has spent its budget on the part that changes and left nothing for the
+part that persists.
 
-A design is specific enough that an implementation can fail to satisfy it. "The system is performant"
-cannot be reconciled toward. It provides no signal about whether the current state is adequate or
-falling short. Specificity is what makes the feedback loop functional.
+**Specific enough to violate.** A design that cannot be failed cannot be reconciled toward. "The
+system is performant" provides no signal about whether the current state is adequate. Specificity is
+what makes the feedback loop functional.
 
-A design is clear about its own boundaries — what is a commitment and what is left to the
-implementation. Ambiguity here is a defect. The boundary between commitment and freedom is the most
-important thing a design communicates, because everything on one side is protected and everything on
-the other side is available for improvement.
+**Clear boundaries.** What is a commitment and what is left to the implementation. Ambiguity here is
+a defect — without this boundary, there is no way to know what to protect and what to improve.
+
+**Generative.** A design builds understanding that transfers to situations it did not enumerate. A
+thesis that produces its conclusions is more durable than a list of assertions, because the thesis
+adapts to new contexts while the list can only be consulted. The reasoning should be visible enough
+that a reader can extend it.
+
+**Every word earns its place.** Designs improve in accuracy and specificity over time, not in length.
+A sentence that restates a previous one, a flourish that does not inform, a word that could be cut —
+each one costs attention that should have gone to signal. Compression is not brevity for its own
+sake. It is respect for the constraint that makes designs work: finite attention, applied to what
+matters.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: declarative-designs
-description: Declare-and-converge model for agentic development. Load when authoring designs, implementing from them, or reconciling implementations.
+description: Designs are the control plane for agentic development. Declare what matters, stay silent on the rest, and let implementations converge.
 ---
 
 # Declarative Designs

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -10,76 +10,85 @@ has, what constraints it operates under. It does not say how. This is not spec-a
 declare-and-converge. The design is the control plane. The code is the data plane. The design
 persists. The implementation converges toward it.
 
-## Silence is the design
+The cycle is: design, implement, use, discover, revise. Speed comes from sparseness — declare
+objectives and constraints, the rest is filled in. Because the design persists across passes, that
+cost is paid once. A detailed spec goes stale. A sparse design compounds.
 
-A design declares what matters and is deliberately silent on everything else. That silence is not
-underspecification — it is the design. A Kubernetes Deployment says "three replicas of this image." It
-does not say which nodes, how to handle failures, or how to sequence a rollout. The controller fills
-that silence, and fills it differently as conditions change. The sparseness is what makes the system
-powerful.
+## Writing designs
 
-A design that says "producers and consumers are decoupled and independently scalable" gives room to
-choose message queues today and shared-memory channels tomorrow. A design that says "use RabbitMQ" has
-locked the implementation without gaining anything. Intent survives technology transitions. Mechanism
-does not.
+A design captures intent — the problem being solved, the constraints, the quality attributes that
+matter. It does not capture mechanism. A design that says "producers and consumers are decoupled and
+independently scalable" gives room to choose message queues today and shared-memory channels tomorrow.
+A design that says "use RabbitMQ" has locked the implementation without gaining anything. Intent
+survives technology transitions. Mechanism does not.
 
-Speed comes from this sparseness. Declare objectives and constraints. The rest is filled in — and
-because the design persists across reconciliation passes, that cost is paid once. A detailed spec is a
-one-time expenditure that goes stale. A sparse design compounds.
+What a design leaves out matters as much as what it includes. A Kubernetes Deployment says "three
+replicas of this image." It does not say which nodes, how to handle failures, or how to sequence a
+rollout. The controller fills that silence, and fills it differently as conditions change. Deliberate
+sparseness is what gives the implementation room to improve over time — it is the space where agents
+add value.
 
-## Reconciliation
+A design must be specific enough that an implementation can fail to satisfy it. "The system is
+performant" cannot be reconciled toward. It provides no signal about whether the current state is
+adequate or falling short. Specificity is what makes the feedback loop functional — the ability to
+distinguish an implementation that satisfies the design from one that does not.
 
-The steady state is continuous reconciliation — evaluating the current implementation against the
-design and closing gaps. Better test coverage, tighter error handling, more accurate documentation,
-cleaner structure. None of these change what the system is. They improve how well the implementation
-satisfies it. This is what makes speed safe. Velocity without a design is drift. Velocity with a
-design is iteration.
+A design must be clear about its own boundaries — what is a commitment and what is left to the
+implementation. Ambiguity here is a defect. Every other part of this system depends on that
+distinction: what to protect during changes, what to test for, what latitude exists for improvement.
 
-When a design changes, the implementation converges toward the new state. Choices that still satisfy
-the updated design survive. Those that do not get replaced. Convergence, not rebuild.
+A design builds understanding that transfers to situations it did not enumerate. A thesis that
+produces its conclusions is more durable than a list of assertions, because the thesis adapts to new
+contexts while the list can only be consulted. The reasoning should be visible enough that a reader
+can extend it.
+
+A design occupies a context window and competes for attention. Every sentence that does not carry
+weight degrades the ones that do. Designs improve in accuracy and specificity over time, not in
+length.
+
+## Implementing from designs
+
+The design is the source of truth. An implementation satisfies it by meeting its objectives,
+constraints, and quality attributes. Where the design is silent, implementation choices are free —
+and should improve over time.
 
 Tests validate design commitments, not implementation details. Tests rooted in implementation break
 when the implementation changes, even when the design is still satisfied. Tests rooted in design
 commitments survive refactors and answer the question that matters: does this implementation do what
 the design says it should?
 
-## Designs grow through use
+When implementation or usage reveals a gap in the design — a failure mode nobody anticipated, a
+quality attribute that only surfaces under real conditions, a constraint that was implicit but never
+captured — that gap becomes a design revision, not an implementation workaround. The implementation
+does not silently become the new design. A workaround encodes the discovery where it cannot be
+reasoned about or tested against, and will be lost the next time the implementation is re-derived. A
+revision makes the discovery permanent.
 
-Designs are not written once. Building and using a system reveals what the design was silent on that
-it should not have been — failure modes nobody anticipated, quality attributes that only surface under
-real conditions, constraints that were implicit but never captured.
+## Reconciliation
 
-When implementation reveals a design was wrong, the design is updated explicitly. The implementation
-does not silently become the new design. When usage reveals a gap, that gap becomes a design revision,
-not an implementation workaround. A workaround encodes the discovery where it cannot be reasoned
-about or tested against, and will be lost the next time the implementation is re-derived. A revision
-makes the discovery permanent.
+Reconciliation is continuous improvement of the implementation without changing what the system is.
+The design holds still. The implementation gets better. This is what makes speed safe — ship fast,
+because there is a defined target to converge toward. Velocity without a design is drift. Velocity
+with a design is iteration.
 
-## What makes a design work
+When a design changes, the implementation converges toward the new state. Choices that still satisfy
+the updated design survive. Those that do not get replaced. Convergence, not rebuild.
 
-A design occupies a context window. It competes for attention with the implementation, the tests, the
-conversation. Every sentence that does not carry weight degrades the ones that do. This is not a style
-concern — it is functional. A wordy design wastes the same resource that makes reconciliation
-possible.
+Beyond convergence, reconciliation is an opportunity to improve the implementation along dimensions
+the design cares about but did not fully achieve on the first pass:
 
-**Intent, not mechanism.** A design captures what and why. Mechanism belongs to the implementation.
-A design that prescribes how has spent its budget on the part that changes and left nothing for the
-part that persists.
+**Correctness.** Does the implementation satisfy the design? Are design commitments tested? Are edge
+cases from constraints covered? Are failure modes handled? Correctness is the foundation —
+everything else assumes the implementation does what the design says it should.
 
-**Specific enough to violate.** A design that cannot be failed cannot be reconciled toward. "The
-system is performant" provides no signal about whether the current state is adequate. Specificity is
-what makes the feedback loop functional.
+**Simplicity.** Can the implementation be simpler while still satisfying the design? Accidental
+complexity accumulates. Patterns that made sense during initial implementation may not survive a
+second look. The design provides the fixed point — anything that can be removed or simplified without
+violating a design commitment should be.
 
-**Clear boundaries.** What is a commitment and what is left to the implementation. Ambiguity here is
-a defect — without this boundary, there is no way to know what to protect and what to improve.
+**Performance.** Do quality attributes hold under real conditions? Can hot paths improve? Performance
+work without a design tends to optimize the wrong things. The design identifies what matters.
 
-**Generative.** A design builds understanding that transfers to situations it did not enumerate. A
-thesis that produces its conclusions is more durable than a list of assertions, because the thesis
-adapts to new contexts while the list can only be consulted. The reasoning should be visible enough
-that a reader can extend it.
-
-**Every word earns its place.** Designs improve in accuracy and specificity over time, not in length.
-A sentence that restates a previous one, a flourish that does not inform, a word that could be cut —
-each one costs attention that should have gone to signal. Compression is not brevity for its own
-sake. It is respect for the constraint that makes designs work: finite attention, applied to what
-matters.
+**Documentation.** Does documentation reflect the current design accurately? Documentation that
+drifts from the design is a source of confusion about what the system is. That drift is a gap like
+any other.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -24,5 +24,6 @@ Designs are source. Implementations are compiled from them. The gap between curr
 ## On Designs Themselves
 
 - Designs declare intent, constraints, and quality attributes — not mechanism
+- A design is specific enough that an implementation can fail to satisfy it
 - Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design
 - Implementation details in a design are revised to capture the underlying intent

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,29 +1,79 @@
 ---
 name: declarative-designs
-description: Objectives for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
+description: Framework for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
 ---
 
 # Declarative Designs
 
-Designs are source. Implementations are compiled from them. The gap between current implementation and declared design closes continuously.
+A design encodes intent — what the system is, why it exists, the constraints it operates under, and
+the qualities that matter. Intent is durable in a way that implementation is not. Languages change,
+architectures get replaced, patterns fall out of favor, but the problem being solved and the
+properties that matter survive those transitions. A design captures what must hold; an implementation
+is one way of making it hold.
 
-## At Rest
+This makes designs the source artifact. Implementations are compiled from them. Any implementation
+that satisfies the design is valid, and where a design is silent on mechanism, implementation choices
+are unconstrained — free to change as better approaches emerge. The boundary between what a design
+commits to and what it leaves open is the most important thing a design communicates, because
+everything on one side is protected and everything on the other side is free.
 
-- Implementations satisfy all objectives, constraints, and quality attributes declared in the design
-- Where a design is silent, implementation choices are unconstrained and improve over time
-- Test coverage validates design commitments, not implementation details
-- Documentation accurately reflects the current design
-- Gaps between design and implementation do not persist
+## Reconciliation
 
-## On Change
+If designs are source and implementations are derived, then the steady state is continuous
+reconciliation — closing the gap between what the design declares and what the implementation does.
+This is not a phase that ends. Agents are imperfect, implementations start rough, and each pass is an
+opportunity to bring the implementation closer to the design's intent. Better test coverage. Tighter
+error handling. More accurate documentation. None of these change what the system is — they improve
+how well the current implementation satisfies it.
 
-- When a design changes, the implementation converges — preserving what still satisfies it, replacing what doesn't
-- When implementation reveals a design is wrong, the design is updated explicitly before the implementation diverges
-- Gaps discovered through usage are captured as design revisions, not implementation workarounds
+Test coverage validates design commitments, not implementation details, because tests rooted in
+implementation break when the implementation changes — even when the design is still satisfied. Tests
+rooted in design commitments are stable across refactors, and they answer the question that matters:
+does this implementation actually do what the design says it should?
 
-## On Designs Themselves
+Documentation reflects the current design, not a historical version of it. When documentation drifts
+from the design, it becomes a source of confusion about what the system actually is. That drift is a
+gap like any other, and it closes the same way.
 
-- Designs declare intent, constraints, and quality attributes — not mechanism
-- A design is specific enough that an implementation can fail to satisfy it
-- Ambiguity about what is a design commitment vs. an implementation choice is a defect in the design
-- Implementation details in a design are revised to capture the underlying intent
+When a design changes, the implementation converges toward the new state. Implementation choices that
+still satisfy the updated design survive; those that don't get replaced. This is convergence, not
+rebuild — most of any implementation is unaffected by most design changes, and preserving what still
+works is part of what makes reconciliation efficient.
+
+## Design evolution
+
+Designs are not written once. They grow through use. Someone builds from the design, uses what they
+built, and discovers that the design was silent on something that turns out to matter — a failure mode
+nobody anticipated, a quality attribute that only becomes visible under real conditions, a constraint
+that was implicit in the team's understanding but never captured. These gaps are the normal output of
+building real systems.
+
+When implementation reveals that a design was wrong, the design is updated explicitly. The
+implementation does not silently become the new design. When usage reveals a gap, that gap becomes a
+design revision, not an implementation workaround. The difference matters: a workaround encodes the
+discovery in a place where it can't be reasoned about, can't be tested against, and will be lost the
+next time the implementation is re-derived. A design revision makes the discovery permanent.
+
+## What makes a design work
+
+Everything above depends on the design being good enough to compile from. A design that fails at its
+job degrades every other part of the system — reconciliation has no target, tests have no anchor, and
+implementation choices have no boundary.
+
+A design declares intent, constraints, and quality attributes — not mechanism. When a design
+prescribes implementation, it captures the wrong thing. The question is always what underlying intent
+the mechanism was trying to serve, and that intent is what belongs in the design. A design that says
+"use a message queue" when it means "producers and consumers are decoupled and independently
+scalable" has locked the implementation without gaining anything — the intent is more durable, more
+portable, and more useful to whoever is compiling from it.
+
+A design must be specific enough that an implementation can fail to satisfy it. A design that says
+"the system is performant" cannot be violated, which means it cannot be reconciled toward. It
+provides no signal about whether the current implementation is adequate or falling short. Specificity
+is what gives a design teeth — the ability to distinguish an implementation that satisfies it from
+one that doesn't.
+
+Ambiguity about what is a design commitment and what is an implementation choice is a defect in the
+design. Every other part of this system depends on that boundary being clear — without it, there is
+no way to know what to protect during changes, what to test for, or what latitude exists for
+improvement. A design that is unclear about its own boundaries cannot function as source.

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -5,25 +5,21 @@ description: How to author, implement from, and reconcile toward declarative des
 
 # Declarative Designs
 
-A declarative design transfers a human's judgment into a persistent artifact that agents reconcile
-toward. It declares what a system is, what properties it has, and what constraints it operates
-under — not how. The design makes the human's judgment persistent and the agent's work cumulative.
-Without it, every session starts from zero, work doesn't accumulate, and quality depends on the human
-reviewing everything — which doesn't scale at agent speed.
+A declarative design makes a human's judgment persistent so that agents can accumulate work against
+it. It declares what a system is, what properties it has, and what constraints it operates under —
+not how to build it. Without a design, every session starts from zero, quality depends on the human
+reviewing every line, and that does not scale at agent speed.
 
 A design is sparse because the human's time is the scarce resource. It captures intent because intent
-persists across implementation changes. It is evaluable because the human can't review every line — if
-the design is satisfied, the implementation is acceptable even if the human hasn't read it. The
-design is the control plane. The code is the data plane. This is how any control system works: a
-stable reference, a feedback loop, and a process that closes the error.
+survives implementation changes. It is evaluable because a satisfied design means the implementation
+is acceptable even unread. The design is the control plane. The code is the data plane. A stable
+reference, a feedback loop, a process that closes the error.
 
 This is not spec-and-implement. A spec is consumed once and goes stale. A design persists across
-sessions, refactors, and rewrites, and the implementation gets better against it each time. As an
+sessions, refactors, and rewrites — the implementation gets better against it each time. As an
 artifact, a design is text that occupies a context window, competes for attention, and steers work.
-Every constraint that follows — compression, specificity, sparseness — is a consequence of this form.
 A thesis that builds understanding is more durable than a list of assertions. Every sentence that
-does not carry weight degrades the ones that do. Designs grow in specificity over time, not in
-length.
+does not carry weight degrades the ones that do.
 
 ## Writing designs
 
@@ -34,10 +30,13 @@ Messages are delivered at least once. Ordering is preserved within a partition k
 independently scalable." This says what the system promises without prescribing how. The
 implementation can use Kafka today and in-process channels tomorrow. The design survives both.
 
-The failure mode is overspecification. "Use Kafka with three partitions, JSON serialization, and
-consumer groups for fan-out." The design has prescribed the implementation. Swap to in-process
-channels for testing? Redesign. The design spent its budget on the part that changes and left nothing
-for the part that persists.
+The failure mode is overspecification — detail at the wrong level. "Use Kafka with three partitions,
+JSON serialization, and consumer groups for fan-out" prescribes the implementation. Swap to
+in-process channels for testing? Redesign. The budget was spent on the part that changes, leaving
+nothing for the part that persists. Overspecification is not excessive detail: "P99 latency under
+100ms at 1000 concurrent connections" is precise and survives any implementation. "Use connection
+pooling with a max of 50 connections" is equally precise but dies with the first architecture change.
+The difference is altitude — one commits to an outcome, the other to a mechanism.
 
 _Test: can the implementation change without the design changing? If not, the design has captured
 mechanism._
@@ -46,29 +45,41 @@ mechanism._
 
 What a design leaves out is as important as what it includes. A Kubernetes Deployment says "three
 replicas of this image" — not which nodes, not how to handle failures, not how to sequence a rollout.
-The controller fills that silence, and fills it differently as conditions change. This is what
-distinguishes a design from a spec: a spec tries to be complete. A design is powerful because it is
-sparse. Sparseness is where implementations improve over time without the design changing.
+The controller fills that silence, and fills it differently as conditions change. A spec tries to be
+complete. A design is powerful because it is incomplete. Sparseness is where implementations improve
+over time without the design changing.
 
-A design operates at the altitude where changing a commitment changes the product. If something can
-change without the product changing, it belongs in the implementation. If it cannot, it belongs in the
-design. This boundary between commitment and freedom is the most important thing a design
-communicates. A design that starts at the right altitude and gradually descends into interface
-details, flag names, or behavioral specifications has lost the boundary. Hold the altitude.
+A design operates where changing a commitment changes the product. If something can change without the
+product changing, it belongs in the implementation. If it cannot, it belongs in the design. This
+boundary between commitment and freedom is the most important thing a design communicates. A design
+that descends into interface details, flag names, or behavioral sequences has lost the boundary — it
+has become a spec wearing a design's name.
+
+Sparseness is not brevity. A design can be long if every sentence is a commitment. It can be short
+and overspecified if those few sentences prescribe mechanism. The axis is commitment density, not word
+count.
+
+_Test: if the implementation filled this silence differently next month, would the product still be
+what the design says it is? If not, the silence is a missing commitment. If so, the silence is
+working._
 
 ### Specificity
 
-Sparseness is not vagueness. A design must be specific enough that an implementation can fail to
-satisfy it. The messaging system's "at least once" is specific — an implementation that drops messages
-under backpressure has failed. "P99 latency under 100ms at 1000 concurrent connections" can be
-reconciled toward. Specificity is what makes the feedback loop functional.
+Sparseness and vagueness look similar but work in opposite directions. A sparse design says less, but
+what it says is sharp enough
+that an implementation can fail to satisfy it. The messaging system's "at least once" is specific: an
+implementation that drops messages under backpressure has failed. "The system handles messages
+reliably" is vague: every implementation trivially satisfies it, so it provides no signal for
+reconciliation.
 
-The failure mode is vagueness. "The system handles messages reliably." Every implementation trivially
-satisfies this, which means it provides no signal for reconciliation. A commitment that cannot be
-violated cannot be converged toward.
+The failure mode is unfalsifiable commitments. A commitment that nothing can violate cannot be
+converged toward. It occupies space in the design without steering work — worse than absence, because
+absence is silent while a vague commitment actively masquerades as a decision made. "The API is easy
+to use" forecloses nothing. "Invalid inputs return structured errors with the failing field, the
+constraint violated, and a valid example" can be tested, failed, and improved against.
 
-_Test: can an implementation fail to satisfy this? If nothing fails it, it is not a design
-commitment._
+_Test: can an implementation fail to satisfy this? If nothing can fail it, it is not a design
+commitment — it is a wish._
 
 ### Boundaries
 
@@ -76,51 +87,47 @@ Every design commitment must be unambiguous about whether it is a commitment. Th
 above draws this boundary: at-least-once delivery is committed, exactly-once is not. A reader knows
 which is which.
 
-The failure mode is ambiguity. "Messages are delivered to consumers." Is ordering a commitment? Is
-exactly-once? The implementation will decide silently, and those silent decisions become implicit
-commitments — impossible to reason about, impossible to test against, discovered only when someone
-makes a different choice and something breaks.
+The failure mode is ambiguity — the silent cousin of vagueness. "Messages are delivered to
+consumers." Is ordering a commitment? Is exactly-once? The implementation will decide, and those
+silent decisions become implicit commitments: impossible to reason about, impossible to test against,
+discovered only when someone makes a different choice and something breaks. Ambiguity does not leave
+freedom; it delegates the decision to whoever moves first, then punishes whoever moves second.
 
-_Test: can two people read this and make different choices about the same concern? If so, the boundary
-between commitment and freedom is missing._
+_Test: can two people read this and make different choices about the same concern? If so, the
+boundary between commitment and freedom is missing._
 
 ## Reconciliation
 
-Reconciliation is the control loop — continuous improvement without changing what the system is. The
-design holds still. The implementation gets better. Velocity without a design is drift. Velocity with
-a design is iteration.
+Reconciliation is the control loop: continuous improvement without changing what the system is. The
+design holds still. The implementation closes the gap between current state and desired state.
 
 ### Closing gaps
 
-An implementation satisfies a design by meeting its objectives, constraints, and quality attributes.
-Where the design is silent, implementation choices are free and should improve over time. Tests
-validate design commitments, not implementation details — tests rooted in implementation break when
-the implementation changes, even when the design is still satisfied. Tests rooted in commitments
-survive refactors and answer the only question that matters: does this implementation do what the
-design says it should?
+An implementation satisfies a design by meeting its commitments. Where the design is silent,
+implementation choices are free and should improve over time. The design determines what gets
+reconciled — correctness, performance, error quality, whatever the design commits to. Dimensions the
+design does not mention are implementation concerns, improved at the implementer's judgment.
 
-Each pass can improve the implementation along any dimension the design cares about. Correctness is
-the foundation — are commitments tested, edge cases covered, failure modes handled? Simplicity is the
-steady-state force — anything that can be removed or simplified without violating a commitment should
-be. These extend to whatever the design declares: performance characteristics, documentation
-accuracy, error quality, API ergonomics. The design determines what gets reconciled.
+Tests validate design commitments, not implementation details. A test rooted in implementation breaks
+when the implementation changes, even when the design is still satisfied. A test rooted in a
+commitment survives refactors and answers the only question that matters: does this implementation do
+what the design says it should?
 
 ### Discovering gaps
 
 Building and using the implementation reveals what the design missed — failure modes nobody
 anticipated, quality attributes that only surface under real conditions, constraints that were
-implicit but never captured. When this happens, the gap becomes a design revision, not an
-implementation workaround. The implementation does not silently become the new design. A workaround
-encodes the discovery where it cannot be reasoned about or tested against, and will be lost the next
-time the implementation is re-derived. A revision makes the discovery permanent.
+implicit but never captured. When this happens, the gap is a design revision, not an implementation
+workaround. The implementation does not silently become the new design.
 
-A design that does not incorporate its discoveries goes stale — and a stale design is worse than a
-gap. A gap is silent. A stale design actively steers toward a state the system has already abandoned.
-
-_Test: does the design reflect current understanding, or a past assumption that survived because
-nobody updated the document?_
-
-### Converging
+A workaround encodes the discovery where it cannot be reasoned about or tested against, and will be
+lost the next time the implementation is re-derived. A revision makes the discovery permanent and
+steerable. A design that does not incorporate its discoveries goes stale — and a stale design is
+worse than a gap. A gap is silent. A stale design actively steers toward a state the system has
+already abandoned.
 
 When a design changes, the implementation converges toward the new state. Choices that still satisfy
 the updated design survive. Those that do not get replaced. Convergence, not rebuild.
+
+_Test: does the design reflect current understanding, or a past assumption that survived because
+nobody updated the document?_

--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: declarative-designs
-description: Framework for design-driven development. Load when authoring designs, implementing from them, deciding what to preserve during changes, or reconciling implementations.
+description: Declare-and-converge model for agentic development. Load when authoring designs, implementing from them, or reconciling implementations.
 ---
 
 # Declarative Designs


### PR DESCRIPTION
## Summary

- Adds `.skills/declarative-designs/SKILL.md` — a portable agent skill for treating designs as the durable source of truth
- Allowlists `.skills/` in the deny-by-default `.gitignore`

The skill defines six principles: designs capture intent not mechanism, implementations are derived and replaceable, reconciliation over perfection, deliberate design revision over implementation drift, convergence on design change, and designs as legible contracts. No implementation details — the skill practices what it describes.

Lives at `.skills/` as a harness-agnostic convention. Needs symlinking into each agent's discovery path (e.g. `~/.claude/skills/`, `~/.config/opencode/skills/`).