### PR TITLE
Add /finish slash command for OpenCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ bin/.*
 !.skills
 !.skills/**
 
+# OpenCode
+!.opencode
+!.opencode/commands
+!.opencode/commands/*.md
+
 # Explicitly ignore
 .bashrc
 .kiro/settings/mcp.json

--- a/.opencode/commands/finish.md
+++ b/.opencode/commands/finish.md
@@ -1,0 +1,20 @@
+---
+description: Run when a task is done — squash, push, PR, review, design check
+subtask: true
+---
+
+Execute this checklist. Parallelize with subagents where possible. Resolve issues yourself and ask
+the user only if a judgment call is needed.
+
+## Checklist
+
+- [ ] Single commit with a message that matches the change
+- [ ] Ensure the PR title and body match the change
+- [ ] Code is reviewed in a fresh context window
+- [ ] Declarative designs are not violated by new changes
+- [ ] Declarative designs are updated as needed for new concepts
+
+## Report
+
+Print the checklist with pass/fail status for each item, the PR url, and details for any failures.
+End with: "Run `/finish` again" if there are unresolved findings, or "Ready to merge" if clean.


### PR DESCRIPTION
## Summary

Adds an OpenCode `/finish` slash command that runs as a fresh subagent to close out a task. Runs a checklist:

- **Git**: squash to single commit, validate message, push with `--force-with-lease`
- **GitHub**: ensure PR exists with descriptive title and accurate body
- **Code review**: bugs, error handling, naming, dead code (report only)
- **Design coherence**: bidirectional check between `*.design.md` files and the changeset — new structures have coverage, existing commitments aren't violated, filenames haven't drifted
- **Hygiene**: debug artifacts, TODO/FIXME, commented-out code (report only)

Stop conditions (uncommitted changes, conflict markers, secrets) block mutations but still run audits. Idempotent — re-run `/finish` after addressing findings until clean.

Also allowlists `.opencode/commands/*.md` in the dotfiles gitignore.