### PR TITLE
Add muse mode for OpenCode

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "amazon-bedrock/us.anthropic.claude-opus-4-6",
+  "permission": {
+    "external_directory": {
+      "~/go/src/github.com/ellistarn/**": "allow"
+    }
+  },
+  "mcp": {
+    "builder-mcp": {
+      "type": "local",
+      "command": ["/Users/etarn/.toolbox/bin/builder-mcp", "--include-tools", "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool"],
+      "enabled": true
+    },
+    "ellis": {
+      "type": "local",
+      "command": ["/Users/etarn/go/bin/muse", "listen"],
+      "enabled": true
+    }
+  },
+  "instructions": ["~/.muse/muse.md"],
+  "tools": {
+    "builder-mcp_*": false,
+    "ellis_*": false
+  },
+  "agent": {
+    "build": {
+      "tools": {
+        "builder-mcp_*": true,
+        "ellis_*": true
+      }
+    },
+    "plan": {
+      "tools": {
+        "builder-mcp_*": true,
+        "ellis_*": true
+      }
+    },
+    "muse": {
+      "description": "Think and respond as your muse",
+      "mode": "primary",
+      "color": "#c4a7e7",
+      "prompt": "{file:~/.muse/muse.md}"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,11 @@ bin/.*
 !.skills/**
 
 # OpenCode
+!.config
+!.config/opencode
+!.config/opencode/opencode.json
+!.config/opencode/skills
+!.config/opencode/skills/**
 !.opencode
 !.opencode/commands
 !.opencode/commands/*.md


### PR DESCRIPTION
## Summary
- Adds muse as a primary OpenCode agent (Tab-switchable alongside Build and Plan)
- Loads `~/.muse/muse.md` as the system prompt via file reference
- MCP tools disabled globally, opted in explicitly per agent — build and plan get MCP, muse stays clean
- All agent config consolidated in `opencode.json`