### PR TITLE
Remove duplicate muse.md from instructions

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -18,7 +18,7 @@
       "enabled": true
     }
   },
-  "instructions": ["~/.muse/muse.md"],
+  "instructions": [],
   "tools": {
     "builder-mcp_*": false,
     "ellis_*": false


### PR DESCRIPTION
## Summary
- The muse agent (`mode: "primary"`) already loads `~/.muse/muse.md` via its `prompt` field
- The `instructions` array was loading the same file a second time, injecting ~6K duplicate tokens into every conversation
- Removes the redundant `instructions` entry, saving ~6K tokens of context per conversation