### PR TITLE
Fix muse agent: dedupe instructions, restrict permissions

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -18,7 +18,7 @@
       "enabled": true
     }
   },
-  "instructions": ["~/.muse/muse.md"],
+  "instructions": [],
   "tools": {
     "builder-mcp_*": false,
     "ellis_*": false
@@ -40,7 +40,11 @@
       "description": "Think and respond as your muse",
       "mode": "primary",
       "color": "#c4a7e7",
-      "prompt": "{file:~/.muse/muse.md}"
+      "prompt": "{file:~/.muse/muse.md}",
+      "permission": {
+        "edit": "deny",
+        "bash": "ask"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove `~/.muse/muse.md` from `instructions` array — the muse agent's `prompt` field already loads it, so it was injected twice (~6K duplicate tokens per conversation)
- Add `permission: { edit: deny, bash: ask }` to the muse agent — it's a planning/thinking persona, not a build agent; edit is denied outright, bash requires approval