### PR TITLE
Set default agent to muse

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6",
+  "default_agent": "muse",
   "permission": {
     "external_directory": {
       "~/go/src/github.com/ellistarn/**": "allow"


### PR DESCRIPTION
Adds `default_agent: muse` to opencode config so new sessions open in the muse agent instead of build.