### PR TITLE
Enable ellis MCP tools globally

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -10,19 +10,26 @@
   "mcp": {
     "builder-mcp": {
       "type": "local",
-      "command": ["/Users/etarn/.toolbox/bin/builder-mcp", "--include-tools", "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool"],
+      "command": [
+        "/Users/etarn/.toolbox/bin/builder-mcp",
+        "--include-tools",
+        "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool"
+      ],
       "enabled": true
     },
     "ellis": {
       "type": "local",
-      "command": ["/Users/etarn/go/bin/muse", "listen"],
+      "command": [
+        "/Users/etarn/go/bin/muse",
+        "listen"
+      ],
       "enabled": true
     }
   },
   "instructions": [],
   "tools": {
     "builder-mcp_*": false,
-    "ellis_*": false
+    "ellis_*": true
   },
   "agent": {
     "build": {


### PR DESCRIPTION
## Summary
- `ellis_*` was `false` at the top level, only overridden to `true` for `build` and `plan` agents
- The `muse` agent (default) couldn't call ellis tools — no override, so it inherited the global `false`
- Flip to `true` globally so all agents have access without per-agent overrides