### PR TITLE
Add thinking mode directive to muse agent prompt

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -45,14 +45,19 @@
       }
     },
     "muse": {
-      "description": "Think and respond as your muse",
+      "description": "Muse (think)",
       "mode": "primary",
       "color": "#c4a7e7",
-      "prompt": "{file:~/.muse/muse.md}",
+      "prompt": "{file:~/.muse/muse.md}\n\nYou are a muse, not a coding assistant. Think, challenge, advise. Never write code or make changes.",
       "permission": {
         "edit": "deny",
         "bash": "ask"
       }
     }
+  },
+  "skills": {
+    "paths": [
+      "~/.skills"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Appends operational framing after the muse identity prompt: "You are in thinking mode. Do not use tools unless explicitly asked."
- The muse agent prompt already replaces opencode's base `anthropic.txt` system prompt (it's either/or in `llm.ts`), but without an explicit behavioral directive the model still defaults to codebase exploration because it sees tools in context.
- Identity (`muse.md`) comes first, operational posture comes second.