### PR TITLE
Stop OpenCode from reading Claude Code instructions

### DIFF
--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -1,0 +1,1 @@
+- You must implement work in a git worktree under ./.worktrees. Do not forget this!!

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ bin/.*
 !.config
 !.config/opencode
 !.config/opencode/opencode.json
+!.config/opencode/AGENTS.md
 !.config/opencode/skills
 !.config/opencode/skills/**
 !.opencode

--- a/.zshrc
+++ b/.zshrc
@@ -66,6 +66,9 @@ export KUBECONFIG=./.kube/config:~/.kube/config
 export CLAUDE_CODE_USE_BEDROCK=1
 export AWS_REGION=us-west-2  # or your preferred region
 
+# OpenCode
+export OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true
+
 ##### Github #####
 export GITHUB_USER=ellistarn
 


### PR DESCRIPTION
## Summary
- Add `~/.config/opencode/AGENTS.md` as the native OpenCode instruction file (copied from `~/.claude/CLAUDE.md`)
- Set `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true` in `.zshrc` to stop OpenCode from reading `~/.claude/CLAUDE.md`
- Whitelist `AGENTS.md` in `.gitignore`

This prevents Claude Code-specific instructions from leaking into custom OpenCode agents (e.g. muse). Symlink `~/.claude/CLAUDE.md -> ~/.config/opencode/AGENTS.md` later if shared instructions are needed.