### PR TITLE
Add ~/.skills to OpenCode skill discovery paths

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -54,5 +54,10 @@
         "bash": "ask"
       }
     }
+  },
+  "skills": {
+    "paths": [
+      "~/.skills"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `skills.paths: ["~/.skills"]` to OpenCode config so skills in `~/.skills/` are discovered
- OpenCode scans `**/SKILL.md` under each configured path; without this, `~/.skills/declarative-designs/SKILL.md` was invisible