### PR TITLE
Fix /finish: run inline instead of as subtask to preserve worktree context

### DIFF
--- a/.opencode/commands/finish.md
+++ b/.opencode/commands/finish.md
@@ -1,15 +1,12 @@
 ---
 description: Run when a task is done — squash, push, PR, review, design check
-subtask: true
 ---
-
-Work is in the active worktree under `.worktrees/`. Find it, its branch, and its PR.
 
 ## Checklist
 
+- [ ] Muse approves the change — `muse ask --new` with the diff and relevant context, then iterate until resolved
 - [ ] Single commit with a message that matches the change (squash if needed)
 - [ ] PR title and body match the landed diff
-- [ ] Code reviewed (re-read the diff in a fresh context)
 - [ ] Declarative designs in `designs/` are not violated
 - [ ] Declarative designs are updated for new concepts
 


### PR DESCRIPTION
## Summary

- Removed `subtask: true` from `/finish` so it runs inline and inherits conversation context
- Removed worktree discovery instructions that only existed to compensate for the lost context
- Added muse review to the checklist
- Tightened review wording