### PR TITLE
Make /finish muse review iterative with explicit exit criterion

### DIFF
--- a/.opencode/commands/finish.md
+++ b/.opencode/commands/finish.md
@@ -4,7 +4,7 @@ description: Run when a task is done — squash, push, PR, review, design check
 
 ## Checklist
 
-- [ ] Muse approves the change — `muse ask --new` with the diff and relevant context, then iterate until resolved
+- [ ] Muse approves the change — `muse ask --new` with the diff and relevant context. If the muse has actionable comments, address them and re-consult with the updated diff. Repeat until the muse responds with no actionable comments.
 - [ ] Single commit with a message that matches the change (squash if needed)
 - [ ] PR title and body match the landed diff
 - [ ] Declarative designs in `designs/` are not violated


### PR DESCRIPTION
## Summary

- Replaces the ambiguous "iterate until resolved" instruction in the muse checklist item with an explicit branch-and-repeat loop: if actionable comments, address and re-consult until none remain.
- The agent was resolving ambiguity in favor of "done" after a single consultation because "resolved" wasn't a testable exit condition. "No actionable comments" is evaluable.