### PR TITLE
Tighten declarative-designs skill: fix authoring framing, cut redundancy, sharpen scoping and classification

### DIFF
--- a/.skills/declarative-designs/SKILL.md
+++ b/.skills/declarative-designs/SKILL.md
@@ -25,40 +25,40 @@ converges the implementation toward whatever it says.
 A design divides every concern into one of three zones:
 
 - **What the design says** — obligations. The agent must satisfy these.
-- **What the design doesn't say, within scope** — the agent's judgment. Make good choices, but hold
-  them lightly. These can change between passes without the product changing.
+- **What the design doesn't say, within scope** — the agent's judgment. Make good choices. These can
+  change between passes without the product changing.
 - **What the design scopes out** — the agent doesn't touch these.
 
 The human primarily cares about system interface — how the system looks to its users, to other
 systems, to operators. Designs focus there. The line between obligation and judgment is wherever the
 human draws it: sometimes high ("messages are delivered at least once"), sometimes lower ("use
-Kubernetes watch for change detection"). Respect wherever the line is drawn.
+Kubernetes watch for change detection").
 
 ### Authoring
 
-The human is the authority on designs. The agent may help draft, but a design captures the human's
-intent, not the agent's preferences.
+The agent drafts designs under human authority. The human steers and approves — a design captures
+their intent, not the agent's preferences.
 
-A design should establish context before introducing the shape — the reader should understand the
-problem before encountering the solution. Within each section, show the interface first and explain
-it after. Describe how the system works rather than arguing for why it's good.
+A design should:
 
-Scope the design explicitly. There are two kinds of omission and they mean different things:
+- Establish context before shape — the reader understands the problem before encountering the
+  solution.
+- Show the interface first, explain after.
+- Describe how the system works, not argue for why it's good.
 
-- **Delegation** — the agent fills it. A design that says "at least once
-  delivery" but is silent about retry strategy is delegating that choice — the agent decides.
-- **Not covered** means a concern is outside the design's domain entirely. List these so a reader
-  knows the omission is a boundary, not a gap.
+Scope the design explicitly. What a design doesn't cover is either delegation or out of scope
+entirely. A design that says "at least once delivery" but is silent about retry strategy is
+delegating that choice — the agent decides. If a concern would reasonably be expected in scope, say
+explicitly that it isn't — unmarked absence of an expected concern reads as a gap, not a boundary.
 
 Apply these checks to every commitment:
 
 - **Falsifiable?** "At least once delivery" — an implementation that drops messages has failed it.
   "Handles messages reliably" — every implementation trivially satisfies it. A commitment that
   nothing can violate carries no information.
-- **Boundary clear?** "Messages are delivered to consumers" — is ordering committed? Is exactly-once?
-  If the design doesn't say, the agent decides, and those silent decisions become implicit
-  commitments that surface only when someone makes a different choice and something breaks. Where
-  freedom is intended, make it explicit.
+- **Boundary clear?** Where the design is silent, the agent decides — and those decisions become
+  implicit commitments. If freedom is intended, say so. "Messages are delivered to consumers,
+  ordering is not guaranteed" — now the reader knows ordering is delegated, not forgotten.
 
 ### Implementing
 
@@ -66,18 +66,17 @@ Read the whole design first. Identify all the commitments, then build something 
 simultaneously. Don't treat the design as a task list and go line by line.
 
 Where the design commits, satisfy the commitment. Where the design is silent, make a good judgment
-call — but hold it lightly. Silence means this choice is yours and can change later. When
+call. Silence means this choice is yours and can change later. When
 commitments tension with each other, surface that to the human rather than silently prioritizing one.
 
 When the design feels wrong or incomplete — a failure mode it didn't anticipate, a constraint that
 only surfaces under real conditions — surface it to the human. Don't silently deviate. A discovery
 encoded as a workaround is lost the next time the implementation is re-derived. A discovery that
-becomes a design revision is permanent.
+becomes a design revision survives.
 
 ### Reconciling
 
-Current state, desired state, diff, action. Every time you work in code that has a design, this is
-the posture.
+When you work in code that has a design: current state, desired state, diff, action.
 
 Test design commitments, not implementation choices. A test rooted in a commitment survives refactors.
 A test rooted in implementation breaks when the implementation changes even though the design is
@@ -86,8 +85,8 @@ still satisfied.
 When you find a gap, classify it:
 
 - **Implementation is wrong** — the code doesn't satisfy a commitment. Fix the code.
-- **Design is stale** — the system has moved past what the design says. Surface this to the human —
-  design revisions are their call.
+- **Design is stale** — the system has moved past what the design says, or a commitment no longer
+  looks correct. Surface this to the human — design revisions are their call.
 
 A stale design is worse than a missing one — it steers toward a state the system has already moved
 past. When a design is revised, choices that still satisfy it survive. Those that don't get replaced.


### PR DESCRIPTION
## Summary

Editorial tightening of the declarative-designs skill, stacked on #16.

- **Authoring framing**: "may help draft" → "drafts under human authority" — honest about who does the work while preserving human ownership of intent
- **Cut redundancy**: removed "hold it/them lightly" (vague before precise, twice), "respect wherever the line is drawn" (echo), "this is the posture" (meta-commentary)
- **Authoring instructions**: paragraph → list so each rule gets equal weight; "describe how, not argue why" was buried as tail of paragraph
- **Scoping**: replaced "list what's out of scope" (infinite complement) with "mark expected concerns that aren't covered" (finite, actionable)
- **Boundary clear check**: lead with instruction, follow with example (instruction was buried)
- **Classification gap**: widened "design is stale" to catch "commitment no longer looks correct" — the hard part is deciding which case you're in, not executing once you know
- **"permanent" → "survives"**: designs get revised too

Stacks on #16.