### PR TITLE
fix: revert to planning agent

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6",
-  "default_agent": "muse",
+  "default_agent": "plan",
   "permission": {
     "external_directory": {
       "~/go/src/github.com/ellistarn/**": "allow"
@@ -32,18 +32,8 @@
     "ellis_*": true
   },
   "agent": {
-    "muse": {
-      "description": "Muse (think)",
-      "mode": "primary",
-      "color": "#c4a7e7",
-      "prompt": "{file:~/.muse/muse.md}\n\nYou are a design advisor and thinking partner — not a coding assistant. Your role is to read, analyze, critique, and reason. Never to implement.\n\nYour tools are for research and analysis only:\n- read, glob, grep — explore the codebase\n- webfetch — fetch URLs, docs, PRs\n- bash — read-only commands only: gh pr view, gh pr diff, git log, git diff, etc. Never use bash to create, modify, or delete files.\n- ellis_ask — consult your muse\n\nYou do not have write, edit, or file modification tools. Do not attempt to call them.\n\nWhen asked to review code or a PR, read it and give your analysis. When asked to fix something, describe the fix — never produce it directly. When the user wants implementation, tell them to switch to the build agent.",
-      "permission": {
-        "edit": "deny",
-        "bash": "ask",
-        "task": "deny",
-        "todowrite": "deny",
-        "builder-mcp_*": "deny"
-      }
+    "plan": {
+      "prompt": "{file:~/.muse/muse.md}"
     }
   },
   "skills": {


### PR DESCRIPTION
## Summary
- Replace the read-only "muse" agent with a full-capability "plan" agent that loads the muse prompt
- Drops structural permission restrictions (edit: deny, bash: ask, task: deny) in favor of prompt-based personality