### PR TITLE
feat: git gone shows remaining branches with status and delete commands

### DIFF
--- a/bin/git-gone
+++ b/bin/git-gone
@@ -1,4 +1,8 @@
 #!/bin/bash
+# git-gone — delete branches whose work has landed; show what remains.
+#
+# Never removes a branch with unmerged local commits or an active worktree.
+# When in doubt, keeps the branch.
 set -euo pipefail
 
 dry_run=false
@@ -10,79 +14,213 @@ dry_run=false
     exit 1
 }
 
+# Colors (TTY only)
+if [ -t 1 ]; then
+    YELLOW='\033[1;33m'; GREEN='\033[0;32m'
+    CYAN='\033[0;36m'; DIM='\033[2m'; BOLD='\033[1m'; RST='\033[0m'
+else
+    YELLOW=''; GREEN=''; CYAN=''; DIM=''; BOLD=''; RST=''
+fi
+
+# ASCII unit separator — git forbids \x1f in branch names, safe delimiter
+SEP=$'\x1f'
+
+remaining_entries=()  # each entry: "branch${SEP}status${SEP}delete_cmd"
+deleted_branches=()
+
+printf "Fetching..."
 git fetch -p -q
+printf " done.\n\n"
 
 current=$(git branch --show-current)
-origin_repo=$(git remote get-url origin | sed -E 's|.*github\.com[:/]||; s|\.git$||; s|/+$||')
+origin_repo=$(git remote get-url origin \
+    | sed -E 's|.*github\.com[:/]||; s|\.git$||; s|/+$||')
 
-# Branches checked out in any worktree are live — never touch them
-worktree_branches=$(git worktree list --porcelain \
-    | grep '^branch refs/heads/' | sed 's|^branch refs/heads/||')
+# Cache worktree list once — parsed N times instead of N subprocess calls
+_worktree_list=$(git worktree list --porcelain)
 
+get_worktree() {
+    printf '%s\n' "$_worktree_list" \
+        | grep -B2 -E "^branch refs/heads/${1}$" \
+        | grep "^worktree " | sed "s/^worktree //" \
+        | head -1 || true
+}
+
+# keep BRANCH STATUS DELETE_CMD
+keep() { remaining_entries+=("${1}${SEP}${2}${SEP}${3}"); }
+
+# remove_branch BRANCH — delete branch; callers must guard against worktrees first.
 remove_branch() {
-    local branch=$1
-    local reason=$2
+    local branch=$1 wt
+    wt=$(get_worktree "$branch")
 
-    local wt
-    wt=$(git worktree list --porcelain \
-        | grep -B2 -E "^branch refs/heads/$branch$" \
-        | grep "^worktree " | sed "s/^worktree //" || true)
+    # Invariant: callers must guard against worktrees before calling this.
+    [ -n "$wt" ] && { printf "BUG: remove_branch called with active worktree for %s\n" "$branch" >&2; return 1; }
 
     if $dry_run; then
-        echo "would remove: $branch ($reason)${wt:+ [worktree: $wt]}"
+        deleted_branches+=("$branch")
         return 0
     fi
 
-    if [ -n "$wt" ]; then
-        git worktree remove "$wt" 2>/dev/null || {
-            echo "skip: $branch (dirty worktree: $wt)"
-            return 0
-        }
-    fi
-    git branch -D "$branch"
+    git branch -D "$branch" >/dev/null
+    deleted_branches+=("$branch")
 }
+
+# Current branch is always kept
+keep "$current" "current" ""
 
 while read -r branch upstream; do
     [ "$branch" = "$current" ] && continue
 
-    # Never touch a branch checked out in a worktree — it's an active session
-    echo "$worktree_branches" | grep -qFx "$branch" && continue
+    wt=$(get_worktree "$branch")
 
     if [ -n "$upstream" ]; then
-        # Has tracking — only clean if upstream ref is gone
-        git show-ref --verify --quiet "$upstream" 2>/dev/null && continue
-        remove_branch "$branch" "tracking branch deleted"
+        if git show-ref --verify --quiet "$upstream" 2>/dev/null; then
+            # Remote still alive — in progress
+            if [ -n "$wt" ]; then
+                keep "$branch" "in progress" \
+                    "git push origin --delete $branch && git worktree remove \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "in progress" \
+                    "git push origin --delete $branch && git branch -D $branch"
+            fi
+            continue
+        fi
+
+        # Remote gone — check for unmerged local commits
+        local_tip=$(git rev-parse "refs/heads/$branch")
+        unmerged=$(git log --oneline "$local_tip" --not --remotes=origin 2>/dev/null)
+        if [ -n "$unmerged" ]; then
+            if [ -n "$wt" ]; then
+                keep "$branch" "abandoned" \
+                    "git worktree remove --force \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "abandoned" "git branch -D $branch"
+            fi
+            continue
+        fi
+        # Remote gone, all commits merged — remove it
+        [ -n "$wt" ] && { keep "$branch" "merged" "git worktree remove \"$wt\" && git branch -D $branch"; continue; }
+        remove_branch "$branch"
     else
-        # No tracking — check for remote ref, then ask gh for merged PR.
-        # gh is the authoritative signal — if it fails or is unavailable,
-        # the branch is kept (safe default).
-        git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null && continue
+        # No upstream tracking ref
+        if git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
+            if [ -n "$wt" ]; then
+                keep "$branch" "in progress" \
+                    "git push origin --delete $branch && git worktree remove \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "in progress" \
+                    "git push origin --delete $branch && git branch -D $branch"
+            fi
+            continue
+        fi
 
-        # Get merge commit SHAs for all merged PRs with this branch name
-        merge_shas=$(gh pr list --repo "$origin_repo" --state merged --head "$branch" \
-            --json mergeCommit --jq '.[].mergeCommit.oid' 2>/dev/null) || continue
-        [ -n "$merge_shas" ] || continue
+        # Ask gh for a merged PR (safe default: keep branch if gh unavailable)
+        merge_shas=$(gh pr list --repo "$origin_repo" --state merged \
+            --head "$branch" --json mergeCommit \
+            --jq '.[].mergeCommit.oid' 2>/dev/null) || {
+            if [ -n "$wt" ]; then
+                keep "$branch" "local" \
+                    "git worktree remove \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "local" "git branch -D $branch"
+            fi
+            continue
+        }
 
-        # Verify local tip is an ancestor of a merge commit — not just a name match
+        if [ -z "$merge_shas" ]; then
+            if [ -n "$wt" ]; then
+                keep "$branch" "local" \
+                    "git worktree remove \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "local" "git branch -D $branch"
+            fi
+            continue
+        fi
+
+        # Verify local tip is an ancestor of the merge commit — not just a name match
         local_tip=$(git rev-parse "refs/heads/$branch")
         is_merged=false
         while read -r sha; do
             [ -n "$sha" ] || continue
             if git merge-base --is-ancestor "$local_tip" "$sha" 2>/dev/null; then
-                is_merged=true
-                break
+                is_merged=true; break
             fi
         done <<< "$merge_shas"
-        $is_merged || continue
 
-        remove_branch "$branch" "merged PR"
+        if [ "$is_merged" = "false" ]; then
+            if [ -n "$wt" ]; then
+                keep "$branch" "local" \
+                    "git worktree remove \"$wt\" && git branch -D $branch"
+            else
+                keep "$branch" "local" "git branch -D $branch"
+            fi
+            continue
+        fi
+
+        [ -n "$wt" ] && { keep "$branch" "merged" "git worktree remove \"$wt\" && git branch -D $branch"; continue; }
+        remove_branch "$branch"
     fi
 done < <(git for-each-ref --format='%(refname:short) %(upstream)' refs/heads/)
 
-# Warn if current branch was deleted on remote, otherwise pull
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+if [ ${#deleted_branches[@]} -gt 0 ]; then
+    verb="Deleted"; $dry_run && verb="Would delete"
+    list=$(IFS=', '; echo "${deleted_branches[*]}")
+    printf "  ${BOLD}%s %d:${RST} ${DIM}%s${RST}\n\n" \
+        "$verb" "${#deleted_branches[@]}" "$list"
+fi
+
+if [ ${#remaining_entries[@]} -gt 0 ]; then
+    # Compute column widths from actual data
+    w_branch=6   # min = len("BRANCH")
+    w_status=11  # min = len("in progress")
+    for entry in "${remaining_entries[@]}"; do
+        b="${entry%%${SEP}*}"
+        rest="${entry#*${SEP}}"
+        s="${rest%%${SEP}*}"
+        [ ${#b} -gt "$w_branch" ] && w_branch=${#b}
+        [ ${#s} -gt "$w_status" ] && w_status=${#s}
+    done
+    col_branch=$(( w_branch + 2 ))
+    col_status=$(( w_status + 2 ))
+
+    printf "  ${BOLD}Remaining branches (%d):${RST}\n\n" "${#remaining_entries[@]}"
+    printf "  ${BOLD}%-${col_branch}s%-${col_status}s%s${RST}\n" \
+        "BRANCH" "STATUS" "DELETE COMMAND"
+
+    # Separator width = branch col + status col + 50 chars for the command col
+    sep_len=$(( col_branch + col_status + 50 ))
+    printf "  "
+    printf '%0.s-' $(seq 1 "$sep_len")
+    printf "\n"
+
+    for entry in "${remaining_entries[@]}"; do
+        b="${entry%%${SEP}*}"
+        rest="${entry#*${SEP}}"
+        s="${rest%%${SEP}*}"
+        d="${rest#*${SEP}}"
+
+        case "$s" in
+            current)       color="$CYAN"   ;;
+            "in progress") color="$GREEN"  ;;
+            abandoned)     color="$YELLOW" ;;
+            *)             color="$DIM"    ;;
+        esac
+
+        [ -z "$d" ] && d="(currently checked out)"
+
+        printf "  ${color}%-${col_branch}s${RST}${DIM}%-${col_status}s${RST}${DIM}%s${RST}\n" \
+            "$b" "$s" "$d"
+    done
+    printf "\n"
+fi
+
+# Warn if current branch's remote was deleted, otherwise pull
 current_upstream=$(git for-each-ref --format='%(upstream)' "refs/heads/$current")
 if [ -n "$current_upstream" ] && ! git show-ref --verify --quiet "$current_upstream" 2>/dev/null; then
-    echo "warning: current branch '$current' was deleted on remote"
+    printf "  ${YELLOW}warning: current branch '%s' was deleted on remote${RST}\n\n" "$current"
 elif ! $dry_run; then
-    git rev-parse --abbrev-ref '@{u}' &>/dev/null && git pull --ff-only
+    git rev-parse --abbrev-ref '@{u}' &>/dev/null && git pull --ff-only -q
 fi


### PR DESCRIPTION
## Summary

After cleanup, `git gone` prints a formatted table of every branch that was **not** deleted — its status and a ready-to-run delete command for manual follow-up.

### Output

```
Fetching... done.

  Deleted 2: old-feature, merged-work

  Remaining branches (4):

  BRANCH              STATUS       DELETE COMMAND
  ---------------------------------------------------------------
  krocodile           current      (currently checked out)
  feature/my-stuff    in progress  git push origin --delete feature/my-stuff && git branch -D feature/my-stuff
  wip/experiment      abandoned    git branch -D wip/experiment
  local-idea          local        git branch -D local-idea
```

### Status taxonomy

| Status | Color | Meaning |
|--------|-------|---------|
| `current` | cyan | currently checked out |
| `in progress` | green | remote tracking ref still alive |
| `abandoned` | yellow | remote gone, unmerged local commits remain |
| `local` | dim | no remote presence, no verified merged PR |
| `merged` | dim | would have been auto-deleted but worktree was dirty |

### Implementation notes

- Dirty worktree is a **failure mode**, not a status — branches use their real status with a `--force` cleanup command in the delete column
- `in progress` delete command includes `git push origin --delete` since the remote is still alive — full teardown
- Worktree list cached once (`_worktree_list`) instead of one subprocess per branch
- Column widths derived dynamically from actual data
- ANSI colors disabled when stdout is not a TTY