### PR TITLE
Add dependency hygiene checks to reconciling-implementations

### DIFF
--- a/.skills/reconciling-implementations/SKILL.md
+++ b/.skills/reconciling-implementations/SKILL.md
@@ -75,6 +75,7 @@ Code's textual surface should not require invisible context to interpret correct
 - [ ] Feature-specific packages compose feature-agnostic packages — dependencies point from features to primitives, never the reverse
 - [ ] Every abstraction earns its existence — no indirection without capability
 - [ ] No duplicated code — small conceptual differences are unified, not copy-pasted
+- [ ] Every dependency earns its place — not superseded by stdlib, not redundant with another dep, not disproportionate to its usage
 - [ ] Types encode constraints — enums for closed sets, no unimplemented API fields
 - [ ] Validation is as far forward as possible — reject invalid state at the boundary
 - [ ] Initialization is pulled to program start — no lazy setup buried in the call stack


### PR DESCRIPTION
## Summary

- Adds two new simplicity checklist items to reconciling-implementations for dependency hygiene
- **Trivial functions are implemented locally** — not imported from a new dependency
- **Non-trivial logic reuses proven dependencies** already in the module rather than being reinvented

Motivation: agents were pulling in unnecessary libraries for simple utility functions. The two items encode the asymmetric decision: don't add a dep for trivial work, but don't reinvent what a proven dep already handles.