### PR TITLE
Add opencode-wakelock plugin, Python 3.14 path, minor skill wording fix

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,42 +1,33 @@
 {
-  "$schema": "https://opencode.ai/config.json",
-  "model": "amazon-bedrock/us.anthropic.claude-opus-4-6",
-  "default_agent": "plan",
-  "permission": {
-    "external_directory": {
-      "~/go/src/github.com/ellistarn/**": "allow"
+  "$schema" : "https://opencode.ai/config.json",
+  "plugin" : [ "opencode-wakelock" ],
+  "model" : "amazon-bedrock/us.anthropic.claude-opus-4-6",
+  "default_agent" : "plan",
+  "permission" : {
+    "external_directory" : {
+      "~/go/src/github.com/ellistarn/**" : "allow"
     }
   },
-  "mcp": {
-    "builder-mcp": {
-      "type": "local",
-      "command": [
-        "/Users/etarn/.toolbox/bin/builder-mcp",
-        "--include-tools",
-        "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool"
-      ],
-      "enabled": true
+  "mcp" : {
+    "builder-mcp" : {
+      "type" : "local",
+      "command" : [ "/Users/etarn/.toolbox/bin/builder-mcp", "--include-tools", "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool" ],
+      "enabled" : false
     },
-    "ellis": {
-      "type": "local",
-      "command": [
-        "/Users/etarn/go/bin/muse",
-        "listen"
-      ],
-      "enabled": true,
-      "timeout": 120000
+    "ellis" : {
+      "type" : "local",
+      "command" : [ "/Users/etarn/go/bin/muse", "listen" ],
+      "enabled" : true,
+      "timeout" : 120000
     }
   },
-  "instructions": [],
-  "tools": {
-    "builder-mcp_*": true,
-    "ellis_*": true
+  "instructions" : [ ],
+  "tools" : {
+    "builder-mcp_*" : true,
+    "ellis_*" : true
   },
-  "agent": {},
-  "skills": {
-    "paths": [
-      "~/.skills",
-      ".skills"
-    ]
+  "agent" : { },
+  "skills" : {
+    "paths" : [ "~/.skills", ".skills" ]
   }
 }

--- a/.skills/finish/SKILL.md
+++ b/.skills/finish/SKILL.md
@@ -12,7 +12,7 @@ programmatically, verify. Items that require human confirmation, ask.
 
 - [ ] **Rebased** — PR branch is rebased to the latest commit on the target remote branch.
 - [ ] **Designs updated** — Design gaps and proposed updates have been reviewed by the human.
-- [ ] **Implementation Quality** — If implementing, load reconciling-implementations and execute the checklist
+- [ ] **Implementation Quality** — If implementing, load the reconciling-implementations skill and execute the checklist
 - [ ] **Design Quality** - If designing, load declaring-designs and execute the checklist
 - [ ] **Validated** — The change works correctly in a development environment, if applicable.
 - [ ] **Committed** — Branch has a single commit. The message summarizes the change clearly — show not tell for perf improvements, logging changes, or anything measurable.

--- a/.zshrc
+++ b/.zshrc
@@ -31,6 +31,7 @@ path+=($HOME/.local/bin)
 path+=(/opt/homebrew/bin)
 path+="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" # GNU Sed for compatibility
 path+=($HOME/go/bin)
+path+=(/opt/homebrew/opt/python@3.14/libexec/bin)
 path+=($HOME/.cargo/bin)
 path+=($HOME/.bun/bin)
 path+=(/usr/local/go/bin)


### PR DESCRIPTION
## Summary
- Install and configure `opencode-wakelock` plugin to prevent macOS sleep during active agent sessions
- Add Python 3.14 homebrew path to `.zshrc`
- Disable `builder-mcp` by default in opencode config
- Minor wording fix in finish skill checklist