### PR TITLE
Enforce worktree-branch name parity and strengthen finish skill

### DIFF
--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -1,2 +1,2 @@
-- Work in .worktrees/$(date +%m%dT%H%M)-$RANDOM-<task>. Do not forget this!!
-- Think about the why behind what I am saying and apply it as you work
+- Work in .worktrees/<branch>. Name branches as $(date +%m%dT%H%M)-$RANDOM-<task>. The worktree directory name must equal the branch name. Do not forget this!!
+- If you start speculating, stop, and find a way to cheaply validate your assumptions

--- a/.skills/finish/SKILL.md
+++ b/.skills/finish/SKILL.md
@@ -6,7 +6,9 @@ description: Completion checklist. Load before declaring any task complete.
 # Finish
 
 Before work is declared complete, verify every item. Items that can be verified
-programmatically, verify. Items that require human confirmation, ask.
+programmatically, verify — run the command and show output. Items that require
+loading another skill, load it with the skill tool and execute its full checklist
+before checking the box. Do not check any box without evidence.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- Worktree directories must equal branch names — no more timestamp-random prefixes
- Finish skill now requires evidence for every checklist item and explicit skill tool loading before checking boxes
- Updated anti-speculation heuristic