### PR TITLE
Make ellis MCP path portable across macOS and Linux

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -20,7 +20,7 @@
     },
     "ellis": {
       "type": "local",
-      "command": ["/Users/etarn/go/bin/muse", "listen"],
+      "command": ["{env:HOME}/go/bin/muse", "listen"],
       "enabled": true,
       "timeout": 120000,
       "environment": {


### PR DESCRIPTION
## Summary
- Replace hardcoded `/Users/etarn/go/bin/muse` with `{env:HOME}/go/bin/muse` so the ellis MCP server works on both macOS (`$HOME=/Users/etarn`) and Linux (`$HOME=/home/etarn`).

## Why
On Linux the absolute macOS path produced `ENOENT: no such file or directory, posix_spawn '/Users/etarn/go/bin/muse'` and ellis showed as `failed` in `opencode mcp list`.

## Validation
Empirically tested three path forms via `opencode mcp list`:

| Path form | Result |
|---|---|
| `/Users/etarn/go/bin/muse` | ENOENT on Linux |
| `~/go/bin/muse` | ENOENT — opencode passes literally to `posix_spawn`, no tilde expansion for MCP command arrays |
| `{env:HOME}/go/bin/muse` | connected — resolves to `/home/etarn/go/bin/muse` |

After the change: `ellis ✓ connected` with resolved command `/home/etarn/go/bin/muse listen`.