### PR TITLE
Track code-server config: bind to port 9001 with no auth

### DIFF
--- a/.config/code-server/config.yaml
+++ b/.config/code-server/config.yaml
@@ -1,0 +1,3 @@
+bind-addr: 127.0.0.1:9001
+auth: none
+cert: false

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ bin/.*
 !.skills
 !.skills/**
 
+# code-server
+!.config/code-server
+!.config/code-server/config.yaml
+
 # OpenCode
 !.config
 !.config/opencode


### PR DESCRIPTION
## Summary
- Add code-server config to version control
- Bind to port 9001 to match Caddy reverse proxy for vscode.etarn
- Disable password auth since access is via SSH tunnel