### PR TITLE
Use Restart=always for systemd services

### DIFF
--- a/.services/systemd/caddy.service
+++ b/.services/systemd/caddy.service
@@ -7,7 +7,7 @@ Type=simple
 User=etarn
 ExecStart=/usr/local/bin/caddy run --config /etc/caddy/Caddyfile
 ExecReload=/usr/local/bin/caddy reload --config /etc/caddy/Caddyfile
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]

--- a/.services/systemd/code-server.service
+++ b/.services/systemd/code-server.service
@@ -7,7 +7,7 @@ Type=simple
 User=etarn
 WorkingDirectory=/home/etarn
 ExecStart=/home/etarn/services/code-server-4.9.1-linux-amd64/bin/code-server --bind-addr 127.0.0.1:9001
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]

--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -9,7 +9,7 @@ WorkingDirectory=/home/etarn
 Environment=OPENCODE_CONFIG=/home/etarn/.config/opencode/opencode.json
 Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 ExecStart=/home/etarn/.opencode/bin/opencode serve --port 9000
-Restart=on-failure
+Restart=always
 RestartSec=5
 
 [Install]


### PR DESCRIPTION
## Summary
- Changes `Restart=on-failure` to `Restart=always` in all three systemd service files (caddy, code-server, opencode)
- `on-failure` only restarts on non-zero exit codes; `always` ensures services survive any exit reason (OOM kills, clean exits, signals, etc.)
- Deployed and verified: all three services active, Caddy routing confirmed with HTTP 200