### PR TITLE
Lower git-gone default stale threshold from 24h to 12h

### DIFF
--- a/bin/git-gone
+++ b/bin/git-gone
@@ -35,7 +35,7 @@ set -euo pipefail
 
 dry_run=false
 stale_mode=false
-stale_hours=24
+stale_hours=12
 
 while [ $# -gt 0 ]; do
     case "$1" in


### PR DESCRIPTION
## Summary
- Lowers the default `--stale` threshold from 24 hours to 12 hours so abandoned agent worktrees get cleaned up faster
- Dirty worktrees remain unconditionally protected regardless of age (the dirty check short-circuits before any stale evaluation)