### PR TITLE
Make wt run in-place and rwt close caller surface

### DIFF
--- a/bin/rwt
+++ b/bin/rwt
@@ -144,3 +144,6 @@ ws_id=$(echo "$ws_line" | grep -o 'workspace:[0-9]*') \
     || die "could not parse workspace id from: $ws_line"
 cmux send --workspace "$ws_id" "cd $worktree_path && opencode" >/dev/null
 cmux send-key --workspace "$ws_id" Enter >/dev/null
+
+# Close the surface that invoked rwt — if it's the last one, the workspace closes too.
+[[ -n "${CMUX_SURFACE_ID:-}" ]] && cmux close-surface --surface "$CMUX_SURFACE_ID" >/dev/null 2>&1 || true

--- a/bin/wt
+++ b/bin/wt
@@ -24,4 +24,5 @@ else
     [[ -d "$wt" ]] || die "worktree not found: $wt"
 fi
 
-exec cmux new-workspace --name "$name" --cwd "$wt" --command "opencode"
+cd "$wt" || die "cannot cd to $wt"
+exec opencode


### PR DESCRIPTION
## Summary
- **wt**: Replace `cmux new-workspace` with `cd + exec opencode` so worktrees open in the current pane instead of spawning a new workspace tab. Fixes `--cwd` flag compat issue on dev desktop.
- **rwt**: Close the calling cmux surface after creating the SSH workspace, since the user has moved to the new one. Uses `CMUX_SURFACE_ID` so only the invoking surface is closed — if it's the last surface, the workspace cleans up automatically.