### PR TITLE
Fix rwt not closing caller workspace

### DIFF
--- a/bin/rwt
+++ b/bin/rwt
@@ -145,5 +145,8 @@ ws_id=$(echo "$ws_line" | grep -o 'workspace:[0-9]*') \
 cmux send --workspace "$ws_id" "cd $worktree_path && opencode" >/dev/null
 cmux send-key --workspace "$ws_id" Enter >/dev/null
 
-# Close the surface that invoked rwt — if it's the last one, the workspace closes too.
-[[ -n "${CMUX_SURFACE_ID:-}" ]] && cmux close-surface --surface "$CMUX_SURFACE_ID" >/dev/null 2>&1 || true
+# Close the calling surface, or the whole workspace if it's the only surface.
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+    cmux close-surface --surface "$CMUX_SURFACE_ID" 2>/dev/null \
+        || cmux close-workspace --workspace "$CMUX_WORKSPACE_ID"
+fi


### PR DESCRIPTION
## Summary
- `cmux close-surface` refuses to close the last surface in a workspace (`Cannot close the last surface`), and the previous fix silently swallowed the error with `|| true`
- Try `close-surface` first (preserves other surfaces/splits), fall back to `close-workspace` when it's the only surface