### PR TITLE
wt/rwt: set upstream tracking on new worktree branches

### DIFF
--- a/bin/rwt
+++ b/bin/rwt
@@ -114,7 +114,7 @@ worktree_path=$(ssh "$SSH_HOST" bash <<EOF
         if git show-ref --verify --quiet "refs/heads/$name"; then
             git worktree add ".worktrees/$name" "$name" >&2
         else
-            git worktree add ".worktrees/$name" -b "$name" >&2
+            git worktree add ".worktrees/$name" -b "$name" @{upstream} >&2
         fi
         echo "created:\$wt"
     else

--- a/bin/wt
+++ b/bin/wt
@@ -15,7 +15,7 @@ repo=$(git rev-parse --show-toplevel 2>/dev/null) || die "not in a git repo"
 if [[ $# -eq 0 ]]; then
     name="$(date +%m%dT%H%M)-$RANDOM"
     wt="$repo/.worktrees/$name"
-    git worktree add "$wt" -b "$name"
+    git worktree add "$wt" -b "$name" @{upstream}
     echo "Created worktree: $name"
     echo "  resume: wt $name"
 else


### PR DESCRIPTION
## Summary
- Pass `@{upstream}` as the start-point to `git worktree add -b` in both `wt` and `rwt`
- Git's `autoSetupMerge` then automatically configures the upstream tracking branch on new worktree branches
- Without this, CRUX code reviews have no destination branch and can't be merged