### PR TITLE
finish skill: require full presubmit, not a subset

### DIFF
--- a/.agents/skills/finish/SKILL.md
+++ b/.agents/skills/finish/SKILL.md
@@ -16,7 +16,7 @@ before checking the box. Do not check any box without evidence.
 - [ ] **Designs updated** — Design gaps and proposed updates have been reviewed by the human.
 - [ ] **Implementation Quality** — If implementing, load the reconciling-implementations skill, execute the checklist, and show the results inline in this checklist.
 - [ ] **Design Quality** - If designing, load declaring-designs, execute the checklist, and show the results inline in this checklist.
-- [ ] **Validated** — The change works correctly in a development environment, if applicable.
+- [ ] **Validated** — Full presubmit has been run and passed.
 - [ ] **Committed** — Branch has a single commit. The message summarizes the change clearly — show not tell for perf improvements, logging changes, or anything measurable.
 - [ ] **PR created** — A pull request exists for this branch. Title and body match the commit message.
 - [ ] **Reviewed** — Muse has reviewed the diff and relevant context. No actionable comments remain.


### PR DESCRIPTION
## Summary
- Tightens the Validated checklist item in the finish skill to require a full presubmit run, not a cherry-picked subset of tests.