### PR TITLE
move AGENTS.md to .opencode/ to prevent leaking into other repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,8 @@
 # Ignore everything
 *
 
-# Include README and AGENTS.md
+# Include README
 !README.md
-!AGENTS.md
 
 # Include git
 !.gitignore
@@ -56,6 +55,9 @@ bin/.*
 !.config/code-server/config.yaml
 
 # OpenCode
+!.opencode
+!.opencode/opencode.json
+!.opencode/AGENTS.md
 !.config
 !.config/opencode
 !.config/opencode/opencode.json

--- a/.opencode/AGENTS.md
+++ b/.opencode/AGENTS.md
@@ -6,15 +6,15 @@ This file is machine-maintained. Agents must never patch it incrementally — al
 
 ## When to regenerate
 
-Regenerate AGENTS.md as part of any PR that adds, removes, or changes tracked files in this repo. The regeneration should be a commit in the PR branch, not a separate PR.
+Regenerate `.opencode/AGENTS.md` as part of any PR that adds, removes, or changes tracked files in this repo. The regeneration should be a commit in the PR branch, not a separate PR.
 
 ## How to regenerate
 
 1. Run `git ls-files` to get the authoritative list of tracked files.
 2. Read every tracked file. For each file, extract its purpose and key details.
-3. Rewrite this file in its entirety. Preserve the two-section structure: this Maintenance header, then the Home Directory reference below.
+3. Rewrite `.opencode/AGENTS.md` in its entirety. Preserve the two-section structure: this Maintenance header, then the Home Directory reference below.
 4. Verify every claim against the actual file contents — do not carry forward stale descriptions.
-5. Commit the updated AGENTS.md alongside the other changes in the PR.
+5. Commit the updated `.opencode/AGENTS.md` alongside the other changes in the PR.
 
 ---
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [".opencode/AGENTS.md"]
+}


### PR DESCRIPTION
## Summary
- Moves `~/AGENTS.md` to `~/.opencode/AGENTS.md` and loads it via `instructions` in `.opencode/opencode.json`
- OpenCode's upward directory walk was discovering `~/AGENTS.md` from any non-git directory under `~`, injecting the full 137-line home repo reference into unrelated sessions
- The `.opencode/` project config is scoped to the git repo boundary, so other repos with their own `.git` are unaffected