### PR TITLE
instrumentation skill: add redundancy gate

### DIFF
--- a/.agents/skills/reconciling-code-instrumentation/SKILL.md
+++ b/.agents/skills/reconciling-code-instrumentation/SKILL.md
@@ -26,6 +26,34 @@ that scope inherits it.
 Handoffs break the call stack. A correlation identifier must flow with the work
 across execution boundaries.
 
+## Redundancy gate
+
+A log line must answer a question that no surrounding log line already answers.
+If removing the line would lose no information, it is noise. If the gate rejects
+a line: add the information as a field on an existing line, or emit nothing.
+
+Signs of a redundant log line:
+
+- An aggregate (count or list) precedes a loop whose iterations are individually
+  logged. The aggregate is derivable.
+- A non-event is logged (e.g., "skipped X") when the action log's absence
+  already communicates the skip.
+- A separate log line carries information that belongs as a field on an existing
+  log line for the same event.
+- Both ends of a call that completes inline are logged. One end is sufficient.
+
+Example. Before (two lines for one event):
+
+    DEBUG creating new informer  gvr=apps/v1/deployments owner=graph/ns/foo
+    DEBUG informer started       gvr=apps/v1/deployments
+
+After (one line, field added):
+
+    DEBUG informer started       gvr=apps/v1/deployments owner=graph/ns/foo
+
+The `owner` field carries the unique information. The entry line is gone — the
+call completes inline and one end is sufficient.
+
 ## Decisions and handoffs
 
 Instrument decisions and handoffs, not computation. Decisions are where the
@@ -34,13 +62,15 @@ system chose a path. Handoffs are where work moves between execution contexts.
 Signs of well-instrumented code:
 
 - The log explains which path was chosen and why alternatives were not.
-- Entry and exit are both logged — a missing exit identifies where the system is
-  stuck.
+- Entry and exit are both logged at DEBUG for operations that can block or hang
+  — a missing exit identifies where the system is stuck. For calls that complete
+  inline, one end is sufficient (see redundancy gate).
 - State changes record previous and new state.
 - Enough context is present to correlate work that crosses execution boundaries.
 - Blocking operations record what is being waited on and how long it took.
   Timeout expiry is logged, not just success.
-- Aggregated work is logged as a set before processing begins.
+- Aggregated work is logged as a set before processing begins, when individual
+  items are not individually logged during processing.
 - Hot inner loops are not instrumented — only the decision to enter the loop and
   the aggregate result.
 
@@ -49,12 +79,31 @@ Signs of well-instrumented code:
 - Add metrics, traces, or spans. This is about structured logs.
 - Instrument serialization, parsing, or pure computation.
 
-## Verification
+## Workflow
 
-Exercise the instrumented code paths through tests. The logs must answer:
+1. **List decision points.** Read the code and identify decisions (path
+   choices), handoffs (work crossing execution boundaries), state machines,
+   and blocking operations. Create a TODO per decision point.
 
-1. Why did this operation start?
-2. For each unit of work: was it acted on, skipped, or blocked? Why?
-3. What was the outcome and duration?
+2. **Check visibility.** For each TODO, check: is the outcome already visible
+   from existing logs? Mark TODOs where the outcome is invisible — these are
+   the candidates. Cancel the rest.
 
-If any question cannot be answered, the instrumentation is incomplete.
+3. **Gate each candidate.** For each surviving TODO, draft the log line, then
+   apply the redundancy gate against the surrounding context. If the gate
+   rejects it, cancel the TODO. If a field on an existing line suffices,
+   rewrite the TODO as a field addition.
+
+4. **Check levels.** Assign the level per § Log levels.
+
+5. **Write the surviving lines.**
+
+6. **Verify.** Exercise the instrumented code paths through tests. The logs
+   must answer:
+   1. Why did this operation start?
+   2. For each unit of work: was it acted on, skipped, or blocked? Why?
+   3. What was the outcome and duration?
+
+   If any question cannot be answered, the instrumentation is incomplete. If
+   the answer appears in more than one log line, the instrumentation has
+   redundancy.


### PR DESCRIPTION
## Summary

The skill told agents what to instrument but not when a log line is
redundant with its surroundings. Applied mechanically, it produced
noise — aggregates before individually-logged loops, skip logs when
the action's absence already communicates the skip, separate lines
for same-event info.

## Changes

- **Redundancy gate** — new section. Four anti-patterns with escape
  hatch (add a field, or do nothing).
- **Entry/exit level** — clarified as DEBUG under Log levels, not
  buried in the bullet list.
- **Bullets tightened** — "chosen path" qualified with "when not
  already visible from adjacent effect log." State changes prefer
  fields over lines. Aggregated work qualified with "when items not
  individually logged."
- **Verification** — flags answers that appear in more than one line.

## Context

Discovered while instrumenting `experimental/controller/`. The original
skill produced ~83 inserted lines. After self-review against these new
principles, 28 were removed as noise — redundant aggregates, non-event
logging, separate lines that should have been fields.