### PR TITLE
opencode: add Claude env vars to systemd service

### DIFF
--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -9,6 +9,8 @@ WorkingDirectory=/home/etarn
 Environment=OPENCODE_CONFIG=/home/etarn/.config/opencode/opencode.json
 Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 Environment=OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1
+Environment=CLAUDE_CODE_USE_BEDROCK=1
+Environment=OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true
 ExecStart=/home/etarn/.opencode/bin/opencode serve --port 9000
 Restart=always
 RestartSec=5


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_CODE_USE_BEDROCK=1` and `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true` to the opencode systemd service
- Required for the opencode server to work correctly with Bedrock