### PR TITLE
opencode: fix Bedrock auth for systemd service

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,6 +3,14 @@
   "plugin": ["opencode-wakelock"],
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
   "default_agent": "plan",
+  "provider": {
+    "amazon-bedrock": {
+      "options": {
+        "region": "us-west-2",
+        "profile": "default"
+      }
+    }
+  },
   "permission": {
     "external_directory": {
       "~/go/src/github.com/ellistarn/**": "allow"

--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -6,14 +6,18 @@ After=network.target
 Type=simple
 User=etarn
 WorkingDirectory=/home/etarn
+Environment=PATH=/home/etarn/bin:/home/etarn/.toolbox/bin:/home/etarn/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OPENCODE_CONFIG=/home/etarn/.config/opencode/opencode.json
 Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 Environment=OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1
 Environment=CLAUDE_CODE_USE_BEDROCK=1
 Environment=OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true
-ExecStart=/home/etarn/.opencode/bin/opencode serve --port 9000
+Environment=AWS_EC2_METADATA_DISABLED=true
+Environment=AWS_ACCOUNT_ID=767520670908
+ExecStart=/home/etarn/bin/opencode-serve --port 9000
+RuntimeMaxSec=3600
 Restart=always
-RestartSec=5
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target

--- a/bin/opencode-serve
+++ b/bin/opencode-serve
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Wrapper for opencode serve that injects AWS credentials from fast-aws-creds.
+# Used by the opencode systemd service since the bundled AWS SDK doesn't
+# support credential_process from ~/.aws/config.
+set -eu
+
+eval "$(fast-aws-creds | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(f'export AWS_ACCESS_KEY_ID={d[\"AccessKeyId\"]}')
+print(f'export AWS_SECRET_ACCESS_KEY={d[\"SecretAccessKey\"]}')
+print(f'export AWS_SESSION_TOKEN={d[\"SessionToken\"]}')
+")"
+
+exec "$HOME/.opencode/bin/opencode" serve "$@"


### PR DESCRIPTION
## Summary
- Add `bin/opencode-serve` wrapper that injects AWS credentials from `fast-aws-creds` before starting opencode
- Disable EC2 instance metadata (IMDS) to prevent the wrong account's credentials from being used
- Set `AWS_ACCOUNT_ID` and `PATH` so `fast-aws-creds` can resolve credentials without IMDS
- Add `RuntimeMaxSec=3600` to refresh credentials hourly via service restart
- Configure Bedrock provider with explicit region in `opencode.json`

## Problem
OpenCode's bundled AWS SDK doesn't support `credential_process` from `~/.aws/config`. Without this fix, it falls back to the EC2 instance profile (account `123367104812`) instead of the user's Bedrock-enabled account (`767520670908`), causing sessions to use the `opencode/big-pickle` model instead of `amazon-bedrock/us.anthropic.claude-opus-4-6-v1`.