### PR TITLE
instrumentation skill: exit fires after the last side effect

### DIFF
--- a/.agents/skills/reconciling-code-instrumentation/SKILL.md
+++ b/.agents/skills/reconciling-code-instrumentation/SKILL.md
@@ -8,76 +8,7 @@ description: >
 # Instrumenting Code
 
 You should be able to reconstruct what the system did and why from its logs
-alone.
-
-## Log levels
-
-- **ERROR** — something went wrong. Errors drive alerts.
-- **INFO** — the system acted on the outside world. Logged once, after the
-  effect.
-- **DEBUG** — why the system did what it did. Off by default.
-
-## Structured context
-
-Every log line must carry enough structured fields to filter to a specific
-operation and component. Set context at scope boundaries — every log line within
-that scope inherits it.
-
-Handoffs break the call stack. A correlation identifier must flow with the work
-across execution boundaries.
-
-## Redundancy gate
-
-A log line must answer a question that no surrounding log line already answers.
-If removing the line would lose no information, it is noise. If the gate rejects
-a line: add the information as a field on an existing line, or emit nothing.
-
-Signs of a redundant log line:
-
-- An aggregate (count or list) precedes a loop whose iterations are individually
-  logged. The aggregate is derivable.
-- A non-event is logged (e.g., "skipped X") when the action log's absence
-  already communicates the skip.
-- A separate log line carries information that belongs as a field on an existing
-  log line for the same event.
-- Both ends of a call that completes inline are logged. One end is sufficient.
-
-Example. Before (two lines for one event):
-
-    DEBUG creating new informer  gvr=apps/v1/deployments owner=graph/ns/foo
-    DEBUG informer started       gvr=apps/v1/deployments
-
-After (one line, field added):
-
-    DEBUG informer started       gvr=apps/v1/deployments owner=graph/ns/foo
-
-The `owner` field carries the unique information. The entry line is gone — the
-call completes inline and one end is sufficient.
-
-## Decisions and handoffs
-
-Instrument decisions and handoffs, not computation. Decisions are where the
-system chose a path. Handoffs are where work moves between execution contexts.
-
-Signs of well-instrumented code:
-
-- The log explains which path was chosen and why alternatives were not.
-- Entry and exit are both logged at DEBUG for operations that can block or hang
-  — a missing exit identifies where the system is stuck. For calls that complete
-  inline, one end is sufficient (see redundancy gate).
-- State changes record previous and new state.
-- Enough context is present to correlate work that crosses execution boundaries.
-- Blocking operations record what is being waited on and how long it took.
-  Timeout expiry is logged, not just success.
-- Aggregated work is logged as a set before processing begins, when individual
-  items are not individually logged during processing.
-- Hot inner loops are not instrumented — only the decision to enter the loop and
-  the aggregate result.
-
-## What this skill does NOT do
-
-- Add metrics, traces, or spans. This is about structured logs.
-- Instrument serialization, parsing, or pure computation.
+alone. Instrument decisions and handoffs, not computation.
 
 ## Workflow
 
@@ -85,25 +16,54 @@ Signs of well-instrumented code:
    choices), handoffs (work crossing execution boundaries), state machines,
    and blocking operations. Create a TODO per decision point.
 
-2. **Check visibility.** For each TODO, check: is the outcome already visible
-   from existing logs? Mark TODOs where the outcome is invisible — these are
-   the candidates. Cancel the rest.
+2. **Check visibility.** For each TODO: is the outcome already visible from
+   existing logs? Cancel TODOs where it is.
 
 3. **Gate each candidate.** For each surviving TODO, draft the log line, then
-   apply the redundancy gate against the surrounding context. If the gate
-   rejects it, cancel the TODO. If a field on an existing line suffices,
-   rewrite the TODO as a field addition.
+   run the per-line checklist below. If the checklist rejects it, cancel the
+   TODO or rewrite it as a field addition on an existing line.
 
-4. **Check levels.** Assign the level per § Log levels.
+4. **Write the surviving lines.**
 
-5. **Write the surviving lines.**
-
-6. **Verify.** Exercise the instrumented code paths through tests. The logs
-   must answer:
+5. **Verify.** Exercise the instrumented code paths. The logs must answer:
    1. Why did this operation start?
    2. For each unit of work: was it acted on, skipped, or blocked? Why?
    3. What was the outcome and duration?
 
-   If any question cannot be answered, the instrumentation is incomplete. If
-   the answer appears in more than one log line, the instrumentation has
+   If any question has no answer, the instrumentation is incomplete. If the
+   answer appears in more than one log line, the instrumentation has
    redundancy.
+
+## Per-line checklist
+
+Run on every new or modified log line.
+
+- [ ] **Level.** ERROR = something went wrong. INFO = acted on the outside
+  world, once, after the effect. DEBUG = why the system did what it did.
+- [ ] **Placement.** The line fires after the side effect it describes, not
+  before. An exit log for an operation that didn't complete is a lie.
+- [ ] **Context.** Set context at scope boundaries so every line within that
+  scope inherits it. Handoffs break the call stack — a correlation identifier
+  must flow with the work across execution boundaries.
+- [ ] **Not redundant.** The line answers a question that no surrounding log
+  line already answers. If removing the line would lose no information, it is
+  noise. When the checklist rejects a line, consider adding the information as
+  a field on an existing line instead.
+
+## What to instrument
+
+- Decisions: which path was chosen and why — when the choice is not already
+  visible from an adjacent effect log.
+- Entry/exit at DEBUG for operations that can block or hang. For calls that
+  complete inline, one end is sufficient.
+- State changes: previous and new state, as fields on existing lines when
+  possible.
+- Handoffs: enough context to correlate work across execution boundaries.
+- Blocking operations: what is being waited on, how long it took, timeout
+  expiry.
+
+## What NOT to instrument
+
+- Metrics, traces, or spans. This is about structured logs.
+- Serialization, parsing, or pure computation.
+- Hot inner loops. Only the decision to enter and the aggregate result.


### PR DESCRIPTION
## Summary

The entry/exit bullet said to log both ends but didn't specify ordering
relative to side effects. This caused an exit log to be placed before
the final API call — `teardown complete` fired before the finalizer
removal. If the removal failed, the log lied.

## Change

One sentence added to the entry/exit bullet:

> Exit fires after the last side effect succeeds, not before — an exit
> log for an operation that didn't complete is a lie.