### PR TITLE
opencode: move project instructions out of .opencode/ to fix worktree startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,8 @@ bin/.*
 !.config/code-server/config.yaml
 
 # OpenCode
-!.opencode
-!.opencode/opencode.json
-!.opencode/AGENTS.md
+!opencode.json
+!MAINTENANCE.md
 !.config
 !.config/opencode
 !.config/opencode/opencode.json

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -6,15 +6,15 @@ This file is machine-maintained. Agents must never patch it incrementally — al
 
 ## When to regenerate
 
-Regenerate `.opencode/AGENTS.md` as part of any PR that adds, removes, or changes tracked files in this repo. The regeneration should be a commit in the PR branch, not a separate PR.
+Regenerate `MAINTENANCE.md` as part of any PR that adds, removes, or changes tracked files in this repo. The regeneration should be a commit in the PR branch, not a separate PR.
 
 ## How to regenerate
 
 1. Run `git ls-files` to get the authoritative list of tracked files.
 2. Read every tracked file. For each file, extract its purpose and key details.
-3. Rewrite `.opencode/AGENTS.md` in its entirety. Preserve the two-section structure: this Maintenance header, then the Home Directory reference below.
+3. Rewrite `MAINTENANCE.md` in its entirety. Preserve the two-section structure: this Maintenance header, then the Home Directory reference below.
 4. Verify every claim against the actual file contents — do not carry forward stale descriptions.
-5. Commit the updated `.opencode/AGENTS.md` alongside the other changes in the PR.
+5. Commit the updated `MAINTENANCE.md` alongside the other changes in the PR.
 
 ---
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "instructions": [".opencode/AGENTS.md"]
+  "instructions": ["MAINTENANCE.md"]
 }


### PR DESCRIPTION
## Summary
- Moved `.opencode/AGENTS.md` to `MAINTENANCE.md` at repo root, referenced via root-level `opencode.json` `instructions` field
- Removed `.opencode/opencode.json` and `.opencode/` gitignore allowlist entries
- `.opencode/` no longer exists in worktrees, eliminating the ~60s npm install of the plugin SDK on every fresh `wt` launch

The file is named `MAINTENANCE.md` (not `AGENTS.md`) to avoid opencode's directory traversal picking it up in sub-projects under `~`.