### PR TITLE
opencode: disable IMDS fallback for Bedrock credentials

### DIFF
--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -12,6 +12,7 @@ Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 Environment=OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1
 Environment=CLAUDE_CODE_USE_BEDROCK=1
 Environment=OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true
+Environment=AWS_EC2_METADATA_DISABLED=true
 ExecStart=/home/etarn/.opencode/bin/opencode serve --port 9000
 Restart=always
 RestartSec=1


### PR DESCRIPTION
## Summary
- Adds `AWS_EC2_METADATA_DISABLED=true` to the opencode systemd service
- When midway credentials expire, the AWS SDK was falling back to the EC2 instance profile (`DevEnvInstanceProfile`), which lacks Bedrock permissions, producing a confusing 403 instead of a clear credentials error
- With IMDS disabled, expired midway now fails fast with a credentials error rather than silently using the wrong identity