### PR TITLE
opencode: add ~/go/bin to systemd service PATH

### DIFF
--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -1,3 +1,2 @@
-- Work in .worktrees/<branch>. Name branches as $(date +%m%dT%H%M)-$RANDOM-<task>. The worktree directory name must equal the branch name. Do not forget this!!
 - Talk to me about algorithms not the code. I do not read the code
 - If you start speculating, stop, and find a way to cheaply validate your assumptions

--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=etarn
 WorkingDirectory=/home/etarn
-Environment=PATH=/home/etarn/bin:/home/etarn/.toolbox/bin:/home/etarn/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+Environment=PATH=/home/etarn/go/bin:/home/etarn/bin:/home/etarn/.toolbox/bin:/home/etarn/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 Environment=OPENCODE_CONFIG=/home/etarn/.config/opencode/opencode.json
 Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 Environment=OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1


### PR DESCRIPTION
## Summary
- Adds `/home/etarn/go/bin` to the opencode systemd service PATH so the server can find Go-installed binaries like `setup-envtest`
- Removes stale worktree branch-naming steering from global AGENTS.md