### PR TITLE
opencode: add AWS_ACCOUNT_ID to systemd service

### DIFF
--- a/.services/systemd/opencode.service
+++ b/.services/systemd/opencode.service
@@ -12,6 +12,7 @@ Environment=OPENCODE_CONFIG_DIR=/home/etarn/.config/opencode
 Environment=OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1
 Environment=CLAUDE_CODE_USE_BEDROCK=1
 Environment=OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true
+Environment=AWS_ACCOUNT_ID=767520670908
 Environment=AWS_EC2_METADATA_DISABLED=true
 ExecStart=/home/etarn/.opencode/bin/opencode serve --port 9000
 Restart=always


### PR DESCRIPTION
## Summary
- Add `AWS_ACCOUNT_ID=767520670908` to the opencode systemd unit so `fast-aws-creds` can pass `--account` to `ada credentials print` without relying on the shell environment.
- Without this, the service depends on a shared `/tmp/aws_credentials_*` cache file created by interactive shell sessions. When that cache expires, the service can't refresh credentials on its own.