### PR TITLE
opencode: add AWS credentials env vars to launchd service

### DIFF
--- a/.services/launchd/com.opencode.serve.plist
+++ b/.services/launchd/com.opencode.serve.plist
@@ -27,6 +27,10 @@
         <string>1</string>
         <key>OPENCODE_DISABLE_CLAUDE_CODE_PROMPT</key>
         <string>true</string>
+        <key>AWS_ACCOUNT_ID</key>
+        <string>767520670908</string>
+        <key>AWS_EC2_METADATA_DISABLED</key>
+        <string>true</string>
     </dict>
     <key>KeepAlive</key>
     <true/>


### PR DESCRIPTION
## Summary
- Adds `AWS_ACCOUNT_ID` and `AWS_EC2_METADATA_DISABLED` to the launchd plist, matching what the systemd service already has
- Fixes `credential provider failed: could not load credentials from any providers` when the local OpenCode server calls Bedrock
- `AWS_ACCOUNT_ID` tells `fast-aws-creds` which account to fetch credentials for; `AWS_EC2_METADATA_DISABLED` prevents the SDK from hanging on the nonexistent EC2 metadata endpoint on macOS