### PR TITLE
opencode: fix launchd service PATH and WorkingDirectory

### DIFF
--- a/.services/launchd/com.opencode.serve.plist
+++ b/.services/launchd/com.opencode.serve.plist
@@ -11,10 +11,12 @@
         <string>--port</string>
         <string>9000</string>
     </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/etarn</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/etarn/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/etarn/bin:/Users/etarn/.toolbox/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/sbin:/bin</string>
         <key>HOME</key>
         <string>/Users/etarn</string>
         <key>OPENCODE_CONFIG</key>


### PR DESCRIPTION
## Summary
- Add `.toolbox/bin` (for `ada`) and `/sbin` (for `md5sum`) to the launchd service PATH so `credential_process` -> `fast-aws-creds` -> `ada` can resolve its dependencies. Without this, auth fails once the 15-minute credential cache expires.
- Add `WorkingDirectory` (`/Users/etarn`) to prevent node_modules reinstalling on every boot, which caused 30+ second hangs on first request. Matches the existing systemd service config.

Both issues were already solved in the systemd service but missed when the launchd plist was created in #71.