### PR TITLE
wt: switch session lookup from sqlite3 to OpenCode HTTP API

### DIFF
--- a/bin/wt-src/main.go
+++ b/bin/wt-src/main.go
@@ -157,9 +157,13 @@ func cmdLs(remoteOnly bool) {
 	local := (<-localCh).entries
 	remote := (<-remoteCh).entries
 
-	enrichLocalWithSessions(local)
+	if err := enrichWithSessions(localServerURL(), local); err != nil {
+		fmt.Fprintf(os.Stderr, "wt: warning: could not fetch local sessions: %v\n", err)
+	}
 	if host != "" {
-		enrichRemoteWithSessions(host, remote)
+		if err := enrichWithSessions(opencodeServerURL(), remote); err != nil {
+			fmt.Fprintf(os.Stderr, "wt: warning: could not fetch remote sessions: %v\n", err)
+		}
 	}
 
 	all := append(local, remote...)

--- a/bin/wt-src/opencode.go
+++ b/bin/wt-src/opencode.go
@@ -6,23 +6,50 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"sort"
-	"strings"
+	"sync"
 	"time"
 )
 
-// OpenCode API types (minimal subset, used for remote attach).
+// OpenCode API types (minimal subset).
 
 type ocSession struct {
 	ID        string `json:"id"`
+	ParentID  string `json:"parentID,omitempty"`
 	Directory string `json:"directory"`
 	Title     string `json:"title"`
 	Time      struct {
 		Created int64 `json:"created"`
 		Updated int64 `json:"updated"`
 	} `json:"time"`
+}
+
+// sessionRecord holds the fields we need from a session for display.
+type sessionRecord struct {
+	id      string
+	dir     string
+	title   string
+	updated int64
+}
+
+// deriveStatus infers session status from the session's last update time.
+// While the agent is generating, the session's time_updated advances as
+// tokens stream in. Once complete, it stops updating.
+func deriveStatus(r sessionRecord) string {
+	if r.updated > 0 {
+		age := time.Since(time.UnixMilli(r.updated))
+		if age < 60*time.Second {
+			return "working"
+		}
+	}
+	return "idle"
+}
+
+func localServerURL() string {
+	if u := os.Getenv("WT_LOCAL_SERVER"); u != "" {
+		return u
+	}
+	return "http://localhost:9000"
 }
 
 func opencodeServerURL() string {
@@ -62,156 +89,105 @@ func findLatestSession(serverURL, directory string) string {
 	return sessions[0].ID
 }
 
-// sessionRecord holds the fields we need from the SQLite session + last message.
-type sessionRecord struct {
-	id             string
-	dir            string
-	title          string
-	updated        int64
-	lastMsgRole    string
-	lastMsgUpdated int64
-}
-
-// deriveStatus infers session status from the last message.
-// While the agent is generating, the assistant message's time_updated advances
-// as tokens stream in. Once complete, it stops updating.
-func deriveStatus(r sessionRecord) string {
-	if r.lastMsgRole == "assistant" && r.lastMsgUpdated > 0 {
-		age := time.Since(time.UnixMilli(r.lastMsgUpdated))
-		if age < 60*time.Second {
-			return "working"
-		}
-	}
-	return "idle"
-}
-
-// opencodeDBPath returns the path to the local OpenCode SQLite database.
-func opencodeDBPath() string {
-	dataDir := os.Getenv("XDG_DATA_HOME")
-	if dataDir == "" {
-		home, _ := os.UserHomeDir()
-		dataDir = filepath.Join(home, ".local", "share")
-	}
-	return filepath.Join(dataDir, "opencode", "opencode.db")
-}
-
-const sessionQuery = `
-SELECT s.id, s.directory, s.title, s.time_updated,
-       CASE WHEN m.data LIKE '%%"role":"assistant"%%' THEN 'assistant' ELSE '' END,
-       COALESCE(m.time_updated, 0)
-FROM session s
-LEFT JOIN message m ON m.session_id = s.id
-  AND m.time_created = (SELECT MAX(time_created) FROM message WHERE session_id = s.id)
-WHERE s.directory IN (%s)
-ORDER BY s.time_updated DESC
-`
-
-func queryLocalSessions(dirs []string) []sessionRecord {
+// fetchSessionsForDirs queries an OpenCode server for sessions across multiple
+// directories in parallel. Each directory gets its own /session?directory= call.
+func fetchSessionsForDirs(serverURL string, dirs []string) ([]sessionRecord, error) {
 	if len(dirs) == 0 {
-		return nil
-	}
-	return querySessionsFromDB("", opencodeDBPath(), dirs)
-}
-
-func queryRemoteSessions(host string, dirs []string) []sessionRecord {
-	if len(dirs) == 0 {
-		return nil
-	}
-	return querySessionsFromDB(host, "$HOME/.local/share/opencode/opencode.db", dirs)
-}
-
-func querySessionsFromDB(host, dbPath string, dirs []string) []sessionRecord {
-	quoted := make([]string, len(dirs))
-	for i, d := range dirs {
-		quoted[i] = "'" + strings.ReplaceAll(d, "'", "''") + "'"
-	}
-	query := fmt.Sprintf(sessionQuery, strings.Join(quoted, ","))
-
-	var out string
-	var err error
-	if host == "" {
-		// Run sqlite3 locally, passing the query via stdin to avoid shell quoting issues.
-		c := exec.Command("sqlite3", "-separator", "\t", dbPath)
-		c.Stdin = strings.NewReader(query)
-		b, e := c.Output()
-		out, err = string(b), e
-	} else {
-		cmd := fmt.Sprintf("sqlite3 -separator '\t' \"%s\" \"%s\"", dbPath, query)
-		out, err = sshRun(host, cmd)
-	}
-	if err != nil {
-		return nil
+		return nil, nil
 	}
 
-	var records []sessionRecord
-	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		if line == "" {
-			continue
+	type result struct {
+		records []sessionRecord
+		err     error
+	}
+
+	results := make([]result, len(dirs))
+	var wg sync.WaitGroup
+	for i, dir := range dirs {
+		wg.Add(1)
+		go func(idx int, d string) {
+			defer wg.Done()
+			u := serverURL + "/session?directory=" + url.QueryEscape(d)
+			resp, err := httpGet(u)
+			if err != nil {
+				results[idx] = result{err: err}
+				return
+			}
+			defer resp.Body.Close()
+
+			var sessions []ocSession
+			if err := json.NewDecoder(resp.Body).Decode(&sessions); err != nil {
+				results[idx] = result{err: fmt.Errorf("decode sessions: %w", err)}
+				return
+			}
+
+			var records []sessionRecord
+			for _, s := range sessions {
+				if s.ParentID != "" {
+					continue // skip subagent sessions
+				}
+				records = append(records, sessionRecord{
+					id:      s.ID,
+					dir:     s.Directory,
+					title:   s.Title,
+					updated: s.Time.Updated,
+				})
+			}
+			results[idx] = result{records: records}
+		}(i, dir)
+	}
+	wg.Wait()
+
+	var all []sessionRecord
+	var firstErr error
+	for _, r := range results {
+		if r.err != nil && firstErr == nil {
+			firstErr = r.err
 		}
-		parts := strings.SplitN(line, "\t", 6)
-		if len(parts) < 6 {
-			continue
-		}
-		var updated, lastMsgUpdated int64
-		fmt.Sscanf(parts[3], "%d", &updated)
-		fmt.Sscanf(parts[5], "%d", &lastMsgUpdated)
-		records = append(records, sessionRecord{
-			id:             parts[0],
-			dir:            parts[1],
-			title:          parts[2],
-			updated:        updated,
-			lastMsgRole:    parts[4],
-			lastMsgUpdated: lastMsgUpdated,
-		})
+		all = append(all, r.records...)
 	}
-	return records
+	return all, firstErr
 }
 
-func enrichLocalWithSessions(entries []WorktreeEntry) {
+func enrichWithSessions(serverURL string, entries []WorktreeEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
 	dirs := make([]string, len(entries))
 	for i, e := range entries {
 		dirs[i] = e.Dir
 	}
-	enrichEntries(entries, queryLocalSessions(dirs))
-}
-
-func enrichRemoteWithSessions(host string, entries []WorktreeEntry) {
-	dirs := make([]string, len(entries))
-	for i, e := range entries {
-		dirs[i] = e.Dir
-	}
-	enrichEntries(entries, queryRemoteSessions(host, dirs))
+	records, err := fetchSessionsForDirs(serverURL, dirs)
+	enrichEntries(entries, records) // use whatever we got, even on partial failure
+	return err
 }
 
 func enrichEntries(entries []WorktreeEntry, records []sessionRecord) {
-	type sessionInfo struct {
-		record sessionRecord
-	}
-	byDir := make(map[string]sessionInfo)
-
+	byDir := make(map[string]sessionRecord)
 	for _, r := range records {
 		existing, ok := byDir[r.dir]
-		if !ok || r.updated > existing.record.updated {
-			byDir[r.dir] = sessionInfo{record: r}
+		if !ok || r.updated > existing.updated {
+			byDir[r.dir] = r
 		}
 	}
 
 	for i := range entries {
-		info, ok := byDir[entries[i].Dir]
+		r, ok := byDir[entries[i].Dir]
 		if !ok {
 			entries[i].Status = "missing"
 			continue
 		}
-		entries[i].SessionID = info.record.id
-		entries[i].Title = info.record.title
-		entries[i].UpdatedAt = time.UnixMilli(info.record.updated)
-		entries[i].Status = deriveStatus(info.record)
+		entries[i].SessionID = r.id
+		entries[i].Title = r.title
+		entries[i].UpdatedAt = time.UnixMilli(r.updated)
+		entries[i].Status = deriveStatus(r)
 	}
 }
 
+var httpClient = &http.Client{Timeout: 5 * time.Second}
+
 func httpGet(u string) (*http.Response, error) {
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Get(u)
+	resp, err := httpClient.Get(u)
 	if err != nil {
 		return nil, err
 	}

--- a/bin/wt-src/opencode_test.go
+++ b/bin/wt-src/opencode_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestFetchSessionsForDirs(t *testing.T) {
+	sessions := map[string][]ocSession{
+		"/repo/.worktrees/wt1": {
+			{ID: "ses_1", Directory: "/repo/.worktrees/wt1", Title: "Fix auth", Time: struct {
+				Created int64 `json:"created"`
+				Updated int64 `json:"updated"`
+			}{Created: 1000, Updated: 2000}},
+		},
+		"/repo/.worktrees/wt2": {
+			{ID: "ses_2", Directory: "/repo/.worktrees/wt2", Title: "Add tests", Time: struct {
+				Created int64 `json:"created"`
+				Updated int64 `json:"updated"`
+			}{Created: 1000, Updated: 3000}},
+			// Subagent session — should be filtered out
+			{ID: "ses_sub", ParentID: "ses_2", Directory: "/repo/.worktrees/wt2", Title: "Explore codebase (@explore subagent)", Time: struct {
+				Created int64 `json:"created"`
+				Updated int64 `json:"updated"`
+			}{Created: 1000, Updated: 4000}},
+		},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dir := r.URL.Query().Get("directory")
+		s := sessions[dir]
+		if s == nil {
+			s = []ocSession{}
+		}
+		json.NewEncoder(w).Encode(s)
+	}))
+	defer srv.Close()
+
+	records, err := fetchSessionsForDirs(srv.URL, []string{
+		"/repo/.worktrees/wt1",
+		"/repo/.worktrees/wt2",
+		"/repo/.worktrees/wt3", // no sessions
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have 2 records (wt1 + wt2), subagent filtered out, wt3 empty
+	if len(records) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(records))
+	}
+
+	byDir := map[string]sessionRecord{}
+	for _, r := range records {
+		byDir[r.dir] = r
+	}
+	if r := byDir["/repo/.worktrees/wt1"]; r.title != "Fix auth" {
+		t.Errorf("wt1: expected title %q, got %q", "Fix auth", r.title)
+	}
+	if r := byDir["/repo/.worktrees/wt2"]; r.title != "Add tests" {
+		t.Errorf("wt2: expected title %q, got %q", "Add tests", r.title)
+	}
+}
+
+func TestFetchSessionsForDirs_ServerDown(t *testing.T) {
+	// Point at a closed server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close()
+
+	records, err := fetchSessionsForDirs(srv.URL, []string{"/repo/.worktrees/wt1"})
+	if err == nil {
+		t.Fatal("expected error for unreachable server")
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records on error, got %d", len(records))
+	}
+}
+
+func TestFetchSessionsForDirs_Empty(t *testing.T) {
+	records, err := fetchSessionsForDirs("http://unused", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if records != nil {
+		t.Errorf("expected nil records, got %v", records)
+	}
+}
+
+func TestEnrichEntries(t *testing.T) {
+	entries := []WorktreeEntry{
+		{Dir: "/repo/.worktrees/wt1"},
+		{Dir: "/repo/.worktrees/wt2"},
+		{Dir: "/repo/.worktrees/wt3"}, // no matching session
+	}
+	records := []sessionRecord{
+		{id: "ses_old", dir: "/repo/.worktrees/wt1", title: "Old", updated: 1000},
+		{id: "ses_new", dir: "/repo/.worktrees/wt1", title: "New", updated: 2000}, // should win
+		{id: "ses_2", dir: "/repo/.worktrees/wt2", title: "Second", updated: 3000},
+	}
+
+	enrichEntries(entries, records)
+
+	// wt1: most recent session wins
+	if entries[0].SessionID != "ses_new" {
+		t.Errorf("wt1: expected session ses_new, got %s", entries[0].SessionID)
+	}
+	if entries[0].Title != "New" {
+		t.Errorf("wt1: expected title %q, got %q", "New", entries[0].Title)
+	}
+
+	// wt2: normal match
+	if entries[1].SessionID != "ses_2" {
+		t.Errorf("wt2: expected session ses_2, got %s", entries[1].SessionID)
+	}
+
+	// wt3: no match → missing
+	if entries[2].Status != "missing" {
+		t.Errorf("wt3: expected status %q, got %q", "missing", entries[2].Status)
+	}
+}
+
+func TestDeriveStatus(t *testing.T) {
+	now := time.Now().UnixMilli()
+
+	tests := []struct {
+		name    string
+		updated int64
+		want    string
+	}{
+		{"recent update is working", now - 10_000, "working"}, // 10s ago
+		{"old update is idle", now - 120_000, "idle"},          // 2min ago
+		{"zero update is idle", 0, "idle"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deriveStatus(sessionRecord{updated: tt.updated})
+			if got != tt.want {
+				t.Errorf("deriveStatus(updated=%d) = %q, want %q", tt.updated, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchSessionsForDirs_PartialFailure(t *testing.T) {
+	// Server that returns 500 for wt2 but succeeds for wt1
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dir := r.URL.Query().Get("directory")
+		if dir == "/repo/.worktrees/wt2" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode([]ocSession{
+			{ID: "ses_1", Directory: dir, Title: "Success", Time: struct {
+				Created int64 `json:"created"`
+				Updated int64 `json:"updated"`
+			}{Created: 1000, Updated: 2000}},
+		})
+	}))
+	defer srv.Close()
+
+	records, err := fetchSessionsForDirs(srv.URL, []string{
+		"/repo/.worktrees/wt1",
+		"/repo/.worktrees/wt2",
+	})
+
+	// Should return an error AND partial results
+	if err == nil {
+		t.Fatal("expected error for partial failure")
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected 1 partial record, got %d", len(records))
+	}
+	if records[0].dir != "/repo/.worktrees/wt1" {
+		t.Errorf("expected wt1 record, got %s", records[0].dir)
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug**: `wt ls` remote session enrichment silently swallowed errors from SSH+sqlite3, causing all remote worktrees to intermittently show dashes with no indication of failure
- **Fix**: Replace sqlite3 queries (local and remote) with parallel per-directory HTTP calls to the OpenCode server API (`GET /session?directory=<dir>`)
- **Bonus**: Filter out subagent sessions (parentID != "") that could override the main session's title

## Changes

- `opencode.go`: Removed sqlite3 query path (`querySessionsFromDB`, `sessionQuery`, `opencodeDBPath`). Added `fetchSessionsForDirs` with parallel goroutines, `enrichWithSessions`, shared `httpClient`
- `main.go`: Errors from session enrichment are now surfaced to stderr as `wt: warning: could not fetch local/remote sessions: <error>`