### PR TITLE
aliases: drop c shortcut for opencode

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -4,7 +4,7 @@ alias kdebug='kubectl run -l debug=$USER -it --image ellistarn/debug $USER-debug
 alias kdebugcleanup='kubectl get pods -l debug=$USER --no-headers=true | cut -f1 -d " " | xargs kubectl delete pods'
 alias ssh-dev="ssh -t $DEV_DESKTOP_HOST 'tmux -CC new -A -s main'"
 alias q="kiro-cli"
-alias c="opencode"
+
 #alias code=kiro
 
 # AWS


### PR DESCRIPTION
## Summary
- Remove the `c` alias for `opencode` — prefer using `wt` or typing `opencode` directly