### PR TITLE
opencode: add autobuild agent with no approval prompts

### DIFF
--- a/.config/opencode/agents/autobuild.md
+++ b/.config/opencode/agents/autobuild.md
@@ -1,0 +1,12 @@
+---
+description: Build mode with no approval prompts
+mode: primary
+permission:
+  doom_loop: deny
+  external_directory: deny
+  question: deny
+---
+
+<!-- Identical to built-in build agent except the three permissions above.
+     All other permissions (bash, edit, read, etc.) are inherited from defaults.
+     Use regular Build (Tab) for sysadmin work that needs external directory access. -->


### PR DESCRIPTION
## Summary
- Adds an `autobuild` primary agent that behaves identically to the built-in `build` agent but never prompts for approval
- `doom_loop: deny` — blocks repeated identical tool calls instead of prompting
- `external_directory: deny` — blocks out-of-project file access instead of prompting
- `question: deny` — prevents mid-task questions

Use regular Build (Tab) for sysadmin work that needs external directory access.