### PR TITLE
fix: correct Sonnet 4.6 Bedrock inference profile ID

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -45,7 +45,7 @@
       }
     },
     "explore": {
-      "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6-v1"
+      "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6"
     }
   }
 }


### PR DESCRIPTION
## Summary
- The explore agent's Bedrock model ID `us.anthropic.claude-sonnet-4-6-v1` doesn't exist — the actual inference profile is `us.anthropic.claude-sonnet-4-6` (no `-v1` suffix). Bedrock naming is inconsistent between Opus and Sonnet here.