### PR TITLE
opencode: add opencode-beads plugin

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-wakelock"],
+  "plugin": ["opencode-wakelock", "opencode-beads"],
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
   "default_agent": "plan",
   "provider": {


### PR DESCRIPTION
## Summary
- Add `opencode-beads` plugin to OpenCode config for beads issue tracker integration
- Plugin auto-injects `bd prime` context on session start and after compaction
- Also upgraded `bd` CLI from v1.0.2 to v1.0.3 (Homebrew, not tracked)