### PR TITLE
opencode: disable LSP, enable compaction pruning

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -3,6 +3,12 @@
   "plugin": ["opencode-wakelock", "opencode-beads"],
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
   "default_agent": "plan",
+  // LSP disabled: full workspace diagnostics stored in context on every edit,
+  // consuming 40%+ of context on large Go projects (gopls). See anomalyco/opencode#6310.
+  "lsp": false,
+  "compaction": {
+    "prune": true
+  },
   "provider": {
     "amazon-bedrock": {
       "options": {


### PR DESCRIPTION
## Summary

- Disable LSP globally — gopls stores full workspace diagnostics in context on every edit, consuming 40%+ of context window on large Go projects with zero signal (210 pre-existing false positives repeated per edit). See anomalyco/opencode#6310.
- Enable `compaction.prune` — drops old tool outputs to reduce context growth in long sessions, keeping compaction viable at high token counts.

## Evidence

Analysis of OpenCode session database across 10+ sessions with >200k peak tokens:

| Session | Peak Tokens | Tool Data % | LSP Diagnostics % |
|---------|------------|-------------|-------------------|
| 826k peak (kro) | 826,476 | 84% | dominant |
| 626k peak (kro) | 626,334 | 93% | dominant |
| 279k peak (kro) | 279,244 | 93% | 39% |

Per-edit diagnostic payload: ~64 KB of identical gopls false positives (`NotAType` errors in test files that compile cleanly). 12 edits = 768 KB of pure noise.