### PR TITLE
Add debug skill: evidence-driven root cause analysis

### DIFF
--- a/.AGENTS.md
+++ b/.AGENTS.md
@@ -19,7 +19,7 @@ This is `ellistarn`'s home directory, tracked as a git repo and bootstrapped wit
 | `.p10k.zsh` | Powerlevel10k prompt theme config. |
 | `.antigenrc` | Empty (antigen bundles are declared inline in `.zshrc`). |
 | `antigen.zsh` | Vendored antigen plugin manager. |
-| `.aliases` | General shell aliases: `terraform→tofu`, `watch→viddy`, kubectl debug pod helpers (`kdebug`, `kdebugcleanup`), `ssh-dev` (tmux on dev desktop), `q→kiro-cli`, Brazil build shorthands (`bb`, `bbr`). |
+| `.aliases` | General shell aliases: `terraform`→`tofu`, `watch`→`viddy`, kubectl debug pod helpers (`kdebug`, `kdebugcleanup`), `ssh-dev` (tmux on dev desktop), `q`→`kiro-cli`, Brazil build shorthands (`bb`, `bbr`). |
 | `.amazon.aliases` | Amazon-specific aliases: Brazil workspace commands (`bb`, `bup`, `brp`, `bws`), `journal`, `cr` (with version-set injection for git worktrees). |
 | `.kubectl.aliases` | Exhaustive generated kubectl aliases (`k`, `kg`, `kd`, `krm`, etc.) covering all resource types, output formats, namespace scopes, and watch flags. |
 | `.condarc` | Conda config: standard Anaconda channels, `auto_activate_base: false`. |
@@ -47,13 +47,13 @@ This is `ellistarn`'s home directory, tracked as a git repo and bootstrapped wit
 | `bin/install-home.sh` | Bootstrap: `git init ~`, add remote (`https://github.com/ellistarn/home.git`), fetch, `reset --hard origin/main`. |
 | `bin/setup/setup.sh` | Orchestrator: runs every other `*.sh` in `bin/setup/` in sorted order. Idempotent. |
 | `bin/setup/dev-tunnel.sh` | macOS only. Installs/configures dnsmasq so `*.etarn` resolves to `127.0.0.1`. Writes `/etc/resolver/etarn`. Cleans up legacy `pf` rules. Requires `DEV_DESKTOP_HOST` and `DEV_DESKTOP_TUNNEL_PORT`. |
-| `bin/setup/services.sh` | Syncs service definitions from `~/.services` to system locations. Linux → systemd (`/etc/systemd/system/`) + Caddy (`/etc/caddy/`). macOS → launchd (`~/Library/LaunchAgents/`). Idempotent; prepends a managed-by marker and prunes orphaned entries. |
+| `bin/setup/services.sh` | Syncs service definitions from `~/.services` to system locations. Linux: systemd (`/etc/systemd/system/`) + Caddy (`/etc/caddy/`). macOS: launchd (`~/Library/LaunchAgents/`). Idempotent; prepends a managed-by marker and prunes orphaned entries. |
 
 ### Git Utilities
 
 | File | Purpose |
 |------|---------|
-| `bin/git-gone` | Cleans up worktrees/branches whose work has landed. Decision: dirty → keep; clean+landed → delete branch+worktree+remote; clean+no-remote+stale (default 12 h) → delete local only; otherwise keep. "Landed" uses ancestry fast-path then `git merge-tree` slow-path to detect squash merges. Flags: `-n`/`--dry-run`, `--stale [HOURS]`. Invoked as `git gone`. |
+| `bin/git-gone` | Cleans up worktrees/branches whose work has landed. Decision: dirty -> keep; clean+landed -> delete branch+worktree+remote; clean+no-remote+stale (default 12 h) -> delete local only; otherwise keep. "Landed" uses ancestry fast-path then `git merge-tree` slow-path to detect squash merges. Flags: `-n`/`--dry-run`, `--stale [HOURS]`. Invoked as `git gone`. |
 
 ---
 
@@ -65,9 +65,9 @@ Service definitions are managed by `bin/setup/services.sh` and synced to system 
 
 | File | Purpose |
 |------|---------|
-| `opencode.service` | Persistent OpenCode server (`opencode serve`) on the dev desktop. Runs as `etarn`, `Restart=always`. Exposes port 9000. Configured via env vars (`OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1`, `AWS_ACCOUNT_ID=767520670908`, `CLAUDE_CODE_USE_BEDROCK=1`, `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true`). |
+| `opencode.service` | Persistent OpenCode server (`opencode serve`) on the dev desktop. Runs as `etarn`, `Restart=always`. Configured via env vars (`OPENCODE_MODEL=amazon-bedrock/us.anthropic.claude-opus-4-6-v1`, `AWS_ACCOUNT_ID=767520670908`, `CLAUDE_CODE_USE_BEDROCK=1`, `OPENCODE_DISABLE_CLAUDE_CODE_PROMPT=true`). |
 | `caddy.service` | Caddy reverse proxy (`Restart=always`). Reads `/etc/caddy/Caddyfile`. |
-| `caddy/Caddyfile` | Listens on `127.0.0.1:9847`. Routes: `opencode.etarn` → `127.0.0.1:9000`, `vscode.etarn` → `127.0.0.1:9001`, `etarn` → file server at `/etc/caddy/www`. All other hosts → 404. |
+| `caddy/Caddyfile` | Listens on `127.0.0.1:9847`. Routes: `opencode.etarn` -> `127.0.0.1:9000`, `vscode.etarn` -> `127.0.0.1:9001`, `etarn` -> file server at `/etc/caddy/www`. All other hosts -> 404. |
 | `caddy/www/index.html` | Static index page served at `http://etarn:9847/`. Lists opencode and vscode service links with JS-injected hostnames. |
 | `code-server.service` | code-server (VS Code in browser) on `127.0.0.1:9001`, `Restart=always`. Binary at `~/services/code-server-4.9.1-linux-amd64/bin/code-server`. |
 
@@ -83,12 +83,12 @@ Service definitions are managed by `bin/setup/services.sh` and synced to system 
 
 | File | Purpose |
 |------|---------|
-| `opencode.json` | Global OpenCode config. Default model: `amazon-bedrock/us.anthropic.claude-opus-4-6-v1`. Default agent: `plan`. Plugins: `opencode-wakelock`, `opencode-beads`. MCP servers: `builder-mcp` (disabled, Amazon internal tools) and `ellis` (disabled, `~/go/bin/muse listen`). Agent overrides: `build` has `doom_loop`/`external_directory`/`question` denied; `explore` uses `amazon-bedrock/us.anthropic.claude-sonnet-4-6`. |
-| `AGENTS.md` | Instructions injected into every agent in this OpenCode config context: talk about algorithms not code; stop and validate rather than speculate. |
+| `opencode.json` | Global OpenCode config. Default model: `amazon-bedrock/us.anthropic.claude-opus-4-6-v1`. Default agent: `plan`. LSP disabled (gopls context bloat — see anomalyco/opencode#6310). Compaction with prune enabled. Plugins: `opencode-wakelock`, `opencode-beads`. MCP servers: `builder-mcp` (disabled, Amazon internal tools) and `ellis` (disabled, `~/go/bin/muse listen`). Agent overrides: `build` has `doom_loop`/`external_directory`/`question` denied; `explore` uses `amazon-bedrock/us.anthropic.claude-sonnet-4-6`. |
+| `AGENTS.md` | Instructions injected into every agent in this OpenCode config context: understand designs first, talk algorithms not code, parallelize with subagents, don't speculate. |
 | `agents/author.md` | Subagent definition for the `author` agent: rewrites design documents from scratch, runs the `declaring-designs` checklist before returning. `bash` permission denied. |
 | `commands/reconcile-agents-md.md` | OpenCode slash-command: loads and executes the `reconcile-agents-md` skill. |
 | `commands/reconcile-organization.md` | OpenCode slash-command: loads and executes the `reconcile-organization` skill. |
-| `commands/reconcile-implementations.md` | OpenCode slash-command: loads and executes the `reconcile-implementations` skill. |
+| `commands/reconcile-quality.md` | OpenCode slash-command: loads and executes the `reconcile-quality` skill. |
 | `commands/reconcile-instrumentation.md` | OpenCode slash-command: loads and executes the `reconcile-instrumentation` skill. |
 | `commands/finish.md` | OpenCode slash-command: loads and executes the `finish` skill. |
 
@@ -108,8 +108,9 @@ Skills are loaded by agents using the skill tool. Each is a `SKILL.md` file.
 
 | Skill | Description |
 |-------|-------------|
-| `reconcile-agents-md` | Regenerate `.AGENTS.md` from scratch. Full process: `git ls-files` → read sources → write with header → spot-check. Never patch; always full replacement. |
-| `reconcile-implementations` | Reconcile implementation quality against designs — correctness, performance, observability, testing, simplicity — in priority order. |
+| `debug` | Root-cause a known bug through evidence, not speculation. Workflow: confirm failure, bootstrap in parallel (characterize failure rate, understand code, add coarse instrumentation), investigate hypotheses in parallel with targeted experiments, resolve and surface instrumentation gaps. |
+| `reconcile-agents-md` | Regenerate `.AGENTS.md` from scratch. Full process: `git ls-files` -> read sources -> write with header -> spot-check. Never patch; always full replacement. |
+| `reconcile-quality` | Reconcile implementation quality against designs — correctness, performance, observability, testing, simplicity — in priority order. |
 | `reconcile-instrumentation` | Reconcile code instrumentation against the system's decision points: list decisions, check visibility, gate each candidate log line, verify logs answer why/what/outcome. |
 | `reconcile-organization` | Reconcile code structure against its architecture by drawing boundaries at the right levels — packages, files, structs, functions. Works one level per invocation. |
 | `declaring-designs` | Checklist for design document quality: standalone, consistent, falsifiable boundaries, earned abstractions, no filler. |

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: debug
+description: >
+  Root-cause a known bug through evidence, not speculation.
+  Load when a test is failing, flaking, or producing wrong results.
+---
+
+# Debugging
+
+You cannot reason your way to a root cause. Code tells you what should happen.
+Only execution tells you what does happen. Every claim about the bug must be
+backed by evidence from a run, not from reading source.
+
+Speed matters. Parallelize everything that can be parallelized — use subagents
+to run independent work concurrently. Run only the failing test, never the full
+suite.
+
+## Workflow
+
+### 1. Explore (parallel)
+
+Launch these as concurrent subagents:
+
+- **Characterize.** Loop the test with sanitizers and race detectors enabled.
+  Record the failure rate. If you cannot trigger a failure, escalate stress.
+  If you still cannot, stop — you cannot debug what you cannot trigger.
+- **Understand.** Read the code paths exercised by the failing test. Identify
+  the decision points, shared state, and concurrency boundaries. Form initial
+  hypotheses — specific, falsifiable claims about what goes wrong. Write them
+  down.
+- **Instrument.** Read the output from the run that prompted this
+  investigation. For the failing operation, the logs must answer: what
+  triggered it, what path was taken at each decision point, and what the
+  outcome was. If any answer is missing, the permanent instrumentation has a
+  gap — surface it. Instrument liberally around the failure: decision points,
+  handoffs, state changes, and dumps of the relevant state at each point.
+
+### 2. Investigate (parallel, iterative)
+
+For each hypothesis, launch a subagent:
+
+1. **State the claim.** "X happens before Y because Z is not synchronized,"
+   or "field F has value V after operation O because path P does not account
+   for condition C."
+2. **Design the experiment.** What instrumentation, assertion, or state dump
+   would confirm or eliminate this claim? Add only that. Prefer assertions
+   (they halt at the violation) over logging (you have to find the needle).
+3. **Run only the failing test.** Loop it enough times to be confident (at
+   least the count from the characterization).
+4. **Read the evidence.** The output confirms, eliminates, or is inconclusive.
+   Inconclusive means the experiment was badly designed — fix the experiment,
+   don't move on.
+
+### 3. Resolve
+
+1. **Fix structurally.** Ask: why was this bug possible in the first place?
+   A bad algorithm, missing abstraction, wrong data ownership, poor code
+   organization, or a leaky API boundary — the root cause is the structural
+   gap that allowed the bug to exist, not the specific instance. The fix must
+   eliminate the category. If the fix doesn't change the answer to "why was
+   this possible," you're patching a symptom.
+2. **Verify.** Run the test the same number of times you used to characterize
+   the failure. Zero failures at that count is the bar.
+3. **Clean up.** Remove all diagnostic instrumentation. Every probe added
+   during investigation is temporary unless it fills an instrumentation gap
+   identified during exploration.


### PR DESCRIPTION
## Summary

- New `debug` skill that enforces hypothesis-driven debugging over speculation
- Four-phase workflow: confirm failure, bootstrap in parallel (characterize failure rate + understand code + add coarse instrumentation), investigate hypotheses in parallel with targeted experiments, resolve and surface instrumentation gaps
- Explicit anti-patterns against speculative fixes, serial hypothesis testing, and running full test suites during investigation