### PR TITLE
bd-setup: drop --stealth, use global gitignore, add --skip-agents

### DIFF
--- a/.gitignore.global
+++ b/.gitignore.global
@@ -6,3 +6,4 @@
 .claude
 .opencode
 .worktrees
+.beads

--- a/bin/bd-setup
+++ b/bin/bd-setup
@@ -15,7 +15,7 @@ while [ "$dir" != "/" ]; do
     echo "  rm -rf $dir/.beads"
     echo ""
     echo "Or initialize manually:"
-    echo "  bd init --stealth --prefix $(basename "$git_root") --non-interactive"
+    echo "  bd init --prefix $(basename "$git_root") --skip-agents --non-interactive"
     exit 1
   fi
   dir="$(dirname "$dir")"
@@ -35,7 +35,7 @@ fi
 # Check for config.yaml, not just .beads/ -- a partial init leaves .beads/ without it
 if [ ! -f ".beads/config.yaml" ]; then
   rm -rf .beads 2>/dev/null
-  bd init --stealth --prefix "$prefix" --non-interactive
+  bd init --prefix "$prefix" --skip-agents --non-interactive
 else
   echo "Beads already initialized (prefix=$prefix)"
 fi


### PR DESCRIPTION
## Summary
- Drop `--stealth` from `bd-setup` — use global `.gitignore` instead of per-repo `.git/info/exclude`
- Add `.beads` to `.gitignore.global` alongside `.claude`, `.opencode`, `.worktrees`
- Use `--skip-agents` since opencode-beads plugin handles context injection via `bd prime`