### PR TITLE
Add missing OpenCode commands for debug, declaring-designs, and using-krocodile skills

### DIFF
--- a/.AGENTS.md
+++ b/.AGENTS.md
@@ -86,11 +86,14 @@ Service definitions are managed by `bin/setup/services.sh` and synced to system 
 | `opencode.json` | Global OpenCode config. Default model: `amazon-bedrock/us.anthropic.claude-opus-4-6-v1`. Default agent: `plan`. LSP disabled (gopls context bloat — see anomalyco/opencode#6310). Compaction with prune enabled. Plugins: `opencode-wakelock`, `opencode-beads`. MCP servers: `builder-mcp` (disabled, Amazon internal tools) and `ellis` (disabled, `~/go/bin/muse listen`). Agent overrides: `build` has `doom_loop`/`external_directory`/`question` denied; `explore` uses `amazon-bedrock/us.anthropic.claude-sonnet-4-6`. |
 | `AGENTS.md` | Instructions injected into every agent in this OpenCode config context: understand designs first, talk algorithms not code, parallelize with subagents, don't speculate. |
 | `agents/author.md` | Subagent definition for the `author` agent: rewrites design documents from scratch, runs the `declaring-designs` checklist before returning. `bash` permission denied. |
+| `commands/debug.md` | OpenCode slash-command: loads and executes the `debug` skill. |
+| `commands/declaring-designs.md` | OpenCode slash-command: loads and executes the `declaring-designs` skill. |
+| `commands/finish.md` | OpenCode slash-command: loads and executes the `finish` skill. |
 | `commands/reconcile-agents-md.md` | OpenCode slash-command: loads and executes the `reconcile-agents-md` skill. |
+| `commands/reconcile-instrumentation.md` | OpenCode slash-command: loads and executes the `reconcile-instrumentation` skill. |
 | `commands/reconcile-organization.md` | OpenCode slash-command: loads and executes the `reconcile-organization` skill. |
 | `commands/reconcile-quality.md` | OpenCode slash-command: loads and executes the `reconcile-quality` skill. |
-| `commands/reconcile-instrumentation.md` | OpenCode slash-command: loads and executes the `reconcile-instrumentation` skill. |
-| `commands/finish.md` | OpenCode slash-command: loads and executes the `finish` skill. |
+| `commands/using-krocodile.md` | OpenCode slash-command: loads and executes the `using-krocodile` skill. |
 
 ---
 

--- a/.config/opencode/commands/debug.md
+++ b/.config/opencode/commands/debug.md
@@ -1,0 +1,5 @@
+---
+description: Root-cause a known bug through evidence, not speculation
+---
+
+Load the `debug` skill and execute it.

--- a/.config/opencode/commands/declaring-designs.md
+++ b/.config/opencode/commands/declaring-designs.md
@@ -1,0 +1,5 @@
+---
+description: Check design document quality — standalone, consistent, falsifiable, no filler
+---
+
+Load the `declaring-designs` skill and execute it.

--- a/.config/opencode/commands/using-krocodile.md
+++ b/.config/opencode/commands/using-krocodile.md
@@ -1,0 +1,5 @@
+---
+description: Krocodile resource authoring reference — load when writing or reviewing krocodile YAML
+---
+
+Load the `using-krocodile` skill and execute it.


### PR DESCRIPTION
## Summary

- Three skills (`debug`, `declaring-designs`, `using-krocodile`) had no corresponding OpenCode slash command — now every skill has one.
- Updated `.AGENTS.md` to list all 8 commands in sorted order.