### PR TITLE
Auto-prompt mwinit when credentials expire on shell open

### DIFF
--- a/bin/login.sh
+++ b/bin/login.sh
@@ -2,7 +2,8 @@
 
 # Idempotent gate for Midway auth and credential sync.
 #
-# --check  (from .zshrc): read-only validation. Warns on problems, never prompts.
+# --check  (from .zshrc): validates cookie & SSH cert. If either is invalid and
+#          stdin is a TTY, prompts mwinit automatically. Non-TTY: warns only.
 # No args  (manual use): force-refresh cookie, sync credentials to dev desktop.
 
 COOKIE_FILE="$HOME/.midway/cookie"
@@ -55,15 +56,25 @@ sync_credentials() {
     return $ok
 }
 
-if [[ "${1:-}" == "--check" ]]; then
-    cookie_valid || { echo "Midway cookie is invalid or missing. Run login.sh to refresh."; }
-    ssh_cert_valid || { echo "SSH certificate is expired or missing. Run login.sh to refresh."; }
-else
+do_refresh() {
     echo "Refreshing mwinit..."
     if ! mwinit -f; then
         echo "mwinit failed — removing cookie so next attempt starts clean."
         rm -f "$COOKIE_FILE"
-        exit 1
+        return 1
     fi
     sync_credentials
+}
+
+if [[ "${1:-}" == "--check" ]]; then
+    if ! cookie_valid || ! ssh_cert_valid; then
+        if [[ -t 0 ]]; then
+            do_refresh
+        else
+            cookie_valid  || echo "Midway cookie is invalid or missing. Run login.sh to refresh."
+            ssh_cert_valid || echo "SSH certificate is expired or missing. Run login.sh to refresh."
+        fi
+    fi
+else
+    do_refresh || exit 1
 fi


### PR DESCRIPTION
## Summary
- `login.sh --check` (called by `.zshrc` on every shell open) now automatically runs `mwinit -f` when the cookie or SSH cert is invalid, instead of just printing a warning.
- Gated on `[[ -t 0 ]]` so non-interactive shells (scripts, pipes, cron) still get the warning-only behavior.
- Extracted `do_refresh()` to share the mwinit+sync logic between `--check` and no-args paths. Uses `return 1` instead of `exit 1` so a failed mwinit in `--check` mode doesn't kill the shell.