### PR TITLE
Deny todowrite globally so agents use beads for task tracking

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -37,6 +37,9 @@
       }
     }
   },
+  "permission": {
+    "todowrite": "deny"
+  },
   "instructions": [],
   "tools": {
     "builder-mcp_*": true,


### PR DESCRIPTION
## Summary
- Adds `"todowrite": "deny"` to global OpenCode permissions, disabling TodoWrite and TodoRead tools for all agents
- Forces agents to use beads (`bd`) for task tracking instead of the built-in TodoWrite, which was competing with the beads context injected by `opencode-beads`