### PR TITLE
Add OpenCodeKiroPlugin via BrazilPlugin loader

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,6 +1,20 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["opencode-wakelock", "opencode-beads"],
+  "plugin": [
+    "opencode-wakelock",
+    "opencode-beads",
+    ["git+ssh://git.amazon.com/pkg/OpenCodeBrazilPlugin", {
+      "plugins": {
+        "kiro-provider": {
+          "package": "OpenCodeKiroPlugin",
+          "version": "1.0",
+          "versionSet": "JersamTestCDKPipeline/development",
+          "entry": "opencode-plugin/index.js",
+          "component": "opencode-plugin"
+        }
+      }
+    }]
+  ],
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
   "default_agent": "plan",
   // LSP disabled: full workspace diagnostics stored in context on every edit,


### PR DESCRIPTION
## Summary
- Adds Kiro/Q Developer inference provider to OpenCode via BrazilPlugin loader
- Uses `git+ssh://` remote approach so the same config works on all machines (Mac + dev desktop)
- Auto-resolves latest plugin version from `JersamTestCDKPipeline/development` version set on each startup

## Prerequisites
- `brazil-package-cache start`
- `mwinit` active
- Kiro IDE signed in (writes auth token to `~/.aws/sso/cache/kiro-auth-token.json`)