### PR TITLE
Enable medium thinking on Bedrock and remove kiro plugin

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -2,18 +2,7 @@
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
     "opencode-wakelock",
-    "opencode-beads",
-    ["git+ssh://git.amazon.com/pkg/OpenCodeBrazilPlugin", {
-      "plugins": {
-        "kiro-provider": {
-          "package": "OpenCodeKiroPlugin",
-          "version": "1.0",
-          "versionSet": "JersamTestCDKPipeline/development",
-          "entry": "opencode-plugin/index.js",
-          "component": "opencode-plugin"
-        }
-      }
-    }]
+    "opencode-beads"
   ],
   "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
   "default_agent": "plan",
@@ -61,11 +50,15 @@
   },
   "agent": {
     "build": {
+      "variant": "medium",
       "permission": {
         "doom_loop": "deny",
         "external_directory": "deny",
         "question": "deny"
       }
+    },
+    "plan": {
+      "variant": "medium"
     },
     "explore": {
       "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6"


### PR DESCRIPTION
## Summary
- Set `variant: "medium"` on both `build` and `plan` agents to enable extended thinking by default
- Remove `OpenCodeBrazilPlugin` / kiro-provider plugin entry (switching back to direct Bedrock)
- Keep Bedrock as default provider (`us.anthropic.claude-opus-4-6-v1` for plan/build, `us.anthropic.claude-sonnet-4-6` for explore)