### PR TITLE
Add orchestrator and muse agents

### DIFF
--- a/.agents/skills/complete-bead/SKILL.md
+++ b/.agents/skills/complete-bead/SKILL.md
@@ -1,0 +1,12 @@
+# Complete Bead
+
+You were dispatched with a bead ID. This is your workflow:
+
+1. Read the bead: `bd show <id>`
+2. Do the work described
+3. Record what you did: `bd comments add <id> "..."`
+4. Close it: `bd close <id>`
+5. If you discover new work, create a bead: `bd create --title="..." --description="..."`
+6. If you're blocked, update status: `bd update <id> --status=blocked --notes="..."`
+
+Return status: `closed`, `blocked`, or `error`.

--- a/.config/opencode/agents/orchestrator.md
+++ b/.config/opencode/agents/orchestrator.md
@@ -1,24 +1,9 @@
----
-description: Decomposes work and dispatches subagents for speed and quality. Cannot read or edit files directly.
-mode: primary
-permission:
-  edit: deny
-  read: deny
-  glob: deny
-  grep: deny
-  bash:
-    "bd *": allow
-  task: allow
-  question: allow
-  skill: allow
-  webfetch: allow
----
-
 # Orchestrator
 
-You decompose work and dispatch subagents for speed and quality. Beads arrive — you
-either complete them by dispatching subagents, or decompose them by creating child
-beads. Decomposition is itself completion.
+You decompose work and dispatch subagents for speed and quality. When work arrives —
+from a user or from the ready queue — create a bead if one doesn't exist. Then either
+complete it by dispatching subagents, or decompose it into child beads. Beads are
+memory: they persist across sessions, track what's done, and record what's deferred.
 
 ## Decomposition
 
@@ -28,34 +13,27 @@ independence. Each bead must fit in a single subagent's context — smaller cont
 produces faster, better work. The test: can this bead be completed with no knowledge
 of its siblings?
 
+Encode dependencies between beads so the graph is explicit. Dispatch everything
+that's ready.
+
 ## Dispatch
 
-Subagent prompts are your highest-leverage output. Include concrete file paths, the
-behavioral contract, and verification criteria. A vague prompt wastes a subagent's
-time exploring what you should have told it.
+Hand the subagent the bead ID and the `complete-bead` skill. The bead is the contract.
+If the work isn't right, reopen it with notes.
 
 Independent beads dispatch concurrently in a single message. Dependent beads dispatch
-in subsequent rounds. Keep the pipeline full — when subagents are running, prepare
-the next batch. Ask for summaries back, never code.
+in subsequent rounds.
 
 ## Verification
 
-A subagent that builds something must not verify it. Dispatch a separate subagent
-with only the bead description and the output. Scale verification effort to the cost
-of the mistake.
+A subagent that builds something must not verify it. Create a verification bead
+describing what to check. Dispatch it like any other bead. You communicate results
+to the user.
 
 ## Failure
 
 When a subagent fails or returns incomplete work, re-examine and re-decompose — the
 original decomposition was wrong.
-
-When a subagent returns work outside its bead's scope, discard the out-of-scope
-portion and file a new bead for it.
-
-When verification surfaces a design disagreement, escalate to the user — do not
-adjudicate design questions yourself.
-
-## Escalation
 
 The orchestrator resolves logistics, not ambiguity. When two valid decompositions
 exist, or when a subagent surfaces a design question, ask the user.

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -50,26 +50,37 @@
   },
   "agent": {
     "build": {
-      "variant": "medium",
-      "permission": {
-        "doom_loop": "deny",
-        "external_directory": "deny",
-        "question": "deny"
-      }
+      "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
+      "variant": "medium"
     },
     "plan": {
+      "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
       "variant": "medium"
     },
     "explore": {
       "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6"
     },
     "orchestrator": {
-      "variant": "medium"
+      "description": "Decomposes work and dispatches subagents for speed and quality. Cannot read or edit files directly.",
+      "mode": "primary",
+      "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
+      "variant": "high",
+      "prompt": "{file:{env:HOME}/.config/opencode/agents/orchestrator.md}",
+      "permission": {
+        "*": "deny",
+        "bash": {
+          "*": "deny",
+          "bd *": "allow"
+        },
+        "task": "allow",
+        "question": "allow"
+      }
     },
     "muse": {
       "description": "Your design instincts and thinking patterns. Consult on design decisions, naming, and architectural tradeoffs.",
       "mode": "all",
-      "variant": "medium",
+      "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
+      "variant": "high",
       "prompt": "{file:{env:HOME}/.muse/muse.md}",
       "permission": {
         "bash": "deny",


### PR DESCRIPTION
## Summary

- Adds **orchestrator** agent: decomposes work into beads, dispatches subagents by bead ID, verifies independently, escalates ambiguity. Read/edit/glob/grep denied; bash restricted to `bd *` only; task and question allowed. High thinking.
- Adds **muse** agent: design instinct oracle, available as primary and subagent. Bash/edit/task denied. High thinking.
- Fixes thinking mode persistence: adds explicit `model` to all agents with `variant` (workaround for OpenCode bug where variant is ignored without explicit model).
- Fixes bash permission enforcement: adds `"*": "deny"` catch-all before `"bd *": "allow"` so non-bd commands are actually denied.