### PR TITLE
Fix complete-bead skill not loading

### DIFF
--- a/.agents/skills/complete-bead/SKILL.md
+++ b/.agents/skills/complete-bead/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: complete-bead
+description: Complete a bead. Load when dispatched with a bead ID.
+---
+
 # Complete Bead
 
 You were dispatched with a bead ID. This is your workflow:


### PR DESCRIPTION
## Summary

- The `complete-bead` skill existed on disk but was invisible to the skill loader because it was missing the YAML frontmatter (`name`/`description`) that all other skills have.
- Added the required frontmatter block so the skill loader can discover and register it.