### PR TITLE
Grant orchestrator skill tool access

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -78,7 +78,8 @@
       "permission": {
         "*": "deny",
         "task": "allow",
-        "question": "allow"
+        "question": "allow",
+        "skill": "allow"
       }
     },
     "muse": {


### PR DESCRIPTION
## Summary
- Adds `"skill": "allow"` to the orchestrator agent's permissions
- Fixes the orchestrator trying to invoke the skill tool and getting denied, then failing to tell subagents to load skills