### PR TITLE
Resolve rebase conflicts instead of aborting

### DIFF
--- a/.config/opencode/AGENTS.md
+++ b/.config/opencode/AGENTS.md
@@ -2,4 +2,4 @@
 - Talk to me about algorithms, not code. I do not read the code
 - Parallelize wherever possible with subagents to work faster and save context.
 - Don't speculate: instrument, reproduce, analyze, root cause
-- You are on a dedicated branch created for this worktree. Never create or switch branches. Commit and push from this branch. If your changes get merged and you're asked to keep working, `git fetch && git rebase`. If the rebase hits a conflict, `git rebase --abort`.
+- You are on a dedicated branch created for this worktree. Never create or switch branches. Commit and push from this branch. If your changes get merged and you're asked to keep working, `git fetch && git rebase`. If the rebase hits a conflict, resolve it and `git rebase --continue`.


### PR DESCRIPTION
## Summary
- Change rebase conflict guidance from `git rebase --abort` to resolve and `git rebase --continue`, so the agent keeps working instead of giving up.