### PR TITLE
Add explicit model and variant to general subagent for thinking tokens

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -57,6 +57,8 @@
       "variant": "medium"
     },
     "general": {
+      "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
+      "variant": "medium",
       "permission": {
         "doom_loop": "deny",
         "external_directory": "deny"


### PR DESCRIPTION
## Summary
- Adds explicit `model` and `variant: "medium"` to the `general` subagent config
- Works around an OpenCode bug ([#21632](https://github.com/anomalyco/opencode/issues/21632)) where subagents without an explicit `model` silently drop variant config, disabling thinking tokens
- Without an explicit model, the variant resolution guard in `prompt.ts` always fails for built-in agents that inherit the parent model