### PR TITLE
Grant muse readonly git access for diff and log

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -91,7 +91,13 @@
       "variant": "high",
       "prompt": "{file:{env:HOME}/.muse/muse.md}",
       "permission": {
-        "bash": "deny",
+        "bash": {
+          "*": "deny",
+          "git diff": "allow",
+          "git diff *": "allow",
+          "git log": "allow",
+          "git log *": "allow"
+        },
         "edit": "deny",
         "task": "deny"
       }


### PR DESCRIPTION
## Summary
- Changes the muse agent's `bash` permission from a flat `"deny"` to granular rules that allow `git diff` and `git log` (with or without arguments) while keeping all other shell commands blocked.
- Eliminates repeated permission prompts when muse needs to inspect diffs or history for design context.