### PR TITLE
finish: move design quality before inquisition

### DIFF
--- a/.agents/skills/finish/SKILL.md
+++ b/.agents/skills/finish/SKILL.md
@@ -14,8 +14,8 @@ before checking the box. Do not check any box without evidence.
 
 - [ ] **Rebased** — PR branch is rebased to the latest commit on the target remote branch.
 - [ ] **Designs updated** — Design gaps have been surfaced to the human and design documents have been updated.
-- [ ] **Inquisition** — Load the inquisition skill and execute it against the full codebase.
 - [ ] **Design Quality** - If designing, load declaring-designs, execute the checklist, and show the results inline in this checklist.
+- [ ] **Inquisition** — Load the inquisition skill and execute it against the full codebase.
 - [ ] **Validated** — Full presubmit has been run and passed.
 - [ ] **Committed** — Branch has a single commit. The message summarizes the change clearly — show not tell for perf improvements, logging changes, or anything measurable.
 - [ ] **PR created** — A pull request exists for this branch. Title and body match the commit message.


### PR DESCRIPTION
Design quality should be established before the inquisition verifies alignment against it.