### PR TITLE
Grant TODO permission to orchestrator agent

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -79,7 +79,8 @@
         "*": "deny",
         "task": "allow",
         "question": "allow",
-        "skill": "allow"
+        "skill": "allow",
+        "todo": "allow"
       }
     },
     "muse": {


### PR DESCRIPTION
Adds `"todo": "allow"` to the orchestrator agent's permission block so it can use the TODO tool.