### PR TITLE
Fix portable symlink, PATH ordering, and add js-dev AWS profiles

### DIFF
--- a/.aws/config
+++ b/.aws/config
@@ -1,9 +1,19 @@
 [default]
-region = us-west-2
-output = json
-credential_process = fast-aws-creds
+region=us-west-2
+output=json
+credential_process=fast-aws-creds
 
 [profile etarn2]
-region = us-west-2
-output = json
-credential_process = fast-aws-creds --account 454269956186
+region=us-west-2
+output=json
+credential_process=fast-aws-creds --account 454269956186
+
+[profile js-dev]
+region=us-west-2
+output=json
+credential_process=fast-aws-creds --account 764488968620
+
+[profile js-dev-ro]
+region=us-west-2
+output=json
+credential_process=fast-aws-creds --account 764488968620 --role ReadOnly

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,11 @@
 {
+  "autoCompactEnabled": false,
+  "enabledPlugins": {
+    "gopls-lsp@claude-plugins-official": true
+  },
+  "env": {
+  },
+  "model": "us.anthropic.claude-opus-4-6-v1",
   "permissions": {
     "allow": [
       "AskUserQuestion",
@@ -71,13 +78,8 @@
       "mcp__aws-knowledge__*"
     ]
   },
-  "model": "us.anthropic.claude-opus-4-6-v1",
   "statusLine": {
-    "type": "command",
-    "command": "/Users/etarn/.claude/statusline.sh"
-  },
-  "enabledPlugins": {
-    "gopls-lsp@claude-plugins-official": true
-  },
-  "autoCompactEnabled": false
+    "command": "/Users/etarn/.claude/statusline.sh",
+    "type": "command"
+  }
 }

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ bin/.*
 !.claude/agents
 !.claude/agents/*.md
 !.claude/.mcp.json
+!.claude/skills
 
 # Agents
 !.agents

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -12,6 +12,9 @@ bind D split-window -v -c "#{pane_current_path}"
 unbind %
 unbind '"'
 
+# Close pane: w (matches Cmd+W muscle memory, no confirmation)
+bind w kill-pane
+
 # Detach: prefix + Escape (moved from d to avoid conflict with split)
 bind Escape detach-client
 

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -1,19 +1,28 @@
-# List of plugins
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-sensible'
+# Prefix: Ctrl+Space
+set -g prefix C-Space
+unbind C-b
+bind C-Space send-prefix
 
+# No delay after Esc (critical for vim/opencode)
+set -sg escape-time 0
 
-# Add true color support
-# $TERM, fix colors / use true colors
-# set -g default-terminal "tmux-256color"
-set -g default-terminal "screen-256color"
-# XXX this seems to be the setting breaking neomutt
-# (artefacts in index after opening the pager)
-# set -g default-terminal "xterm-256color"
-set -ga terminal-overrides ",*256col*:Tc"
+# Splits: d/D mirrors Cmd+D / Cmd+Shift+D
+bind d split-window -h -c "#{pane_current_path}"
+bind D split-window -v -c "#{pane_current_path}"
+unbind %
+unbind '"'
 
-# Enable mouse scrolling and pane selection
+# Detach: prefix + Escape (moved from d to avoid conflict with split)
+bind Escape detach-client
+
+# Windows start at 1 (matches keyboard layout)
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Visual feedback when prefix is active
+set -g status-style "bg=default"
+set -g status-left "#{?client_prefix,#[bg=blue] PREFIX ,} "
+
+# Mouse
 set -g mouse on
-
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'

--- a/.zshrc
+++ b/.zshrc
@@ -30,11 +30,11 @@ fi
 ##### Zsh #####
 
 ##### Paths #####
-path+=($HOME/bin)
-path+=($HOME/.local/bin)
+path=($HOME/bin $HOME/.local/bin $path)
+
 path+=($HOME/.opencode/bin)
 path+=(/opt/homebrew/bin)
-path+="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH" # GNU Sed for compatibility
+path+=(/usr/local/opt/gnu-sed/libexec/gnubin) # GNU Sed for compatibility
 path+=($HOME/go/bin)
 path+=(/opt/homebrew/opt/python@3.14/libexec/bin)
 path+=($HOME/.cargo/bin)

--- a/.zshrc
+++ b/.zshrc
@@ -30,17 +30,20 @@ fi
 ##### Zsh #####
 
 ##### Paths #####
-path=($HOME/bin $HOME/.local/bin $path)
-
-path+=($HOME/.opencode/bin)
-path+=(/opt/homebrew/bin)
-path+=(/usr/local/opt/gnu-sed/libexec/gnubin) # GNU Sed for compatibility
-path+=($HOME/go/bin)
-path+=(/opt/homebrew/opt/python@3.14/libexec/bin)
-path+=($HOME/.cargo/bin)
-path+=($HOME/.bun/bin)
-path+=(/usr/local/go/bin)
-path+=(/usr/local/bin)
+path=(
+  $HOME/bin
+  $HOME/.local/bin
+  $HOME/.opencode/bin
+  $HOME/go/bin
+  $HOME/.cargo/bin
+  $HOME/.bun/bin
+  /opt/homebrew/bin
+  /opt/homebrew/opt/python@3.14/libexec/bin
+  /usr/local/opt/gnu-sed/libexec/gnubin
+  /usr/local/go/bin
+  /usr/local/bin
+  $path
+)
 
 ##### Scripts #####
 for dir in $(find "$HOME/bin" -type d); do


### PR DESCRIPTION
## Summary
- Fix `.claude/skills` symlink to use relative path (`../.agents/skills`) so it resolves on both macOS and Linux remotes
- Fix broken zsh PATH array syntax for gnu-sed (was appending colon-separated string literal)
- Prepend `~/bin` and `~/.local/bin` to PATH instead of appending
- Add `js-dev` and `js-dev-ro` AWS profiles (account 764488968620)
- Alphabetize `.claude/settings.json` keys
- Remove broken bd pre-commit hook (`bd sync --flush-only` doesn't exist)