### PR TITLE
Fix credential shims to dynamically resolve real binary path

### DIFF
--- a/bin/ada
+++ b/bin/ada
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -u
 
-REAL_ADA="/Users/etarn/.toolbox/bin/ada"
+# Find real ada by searching PATH, skipping this shim
+SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+REAL_ADA=$(which -a ada 2>/dev/null | grep -v "$SELF" | head -1)
+if [[ -z "$REAL_ADA" ]]; then
+    echo "ada: real binary not found in PATH" >&2
+    exit 1
+fi
 TIMEOUT=900
 
 # Pass through if not "credentials print"

--- a/bin/aws
+++ b/bin/aws
@@ -1,7 +1,13 @@
 #!/bin/bash
 set -u
 
-REAL_AWS="/usr/local/bin/aws"
+# Find real aws by searching PATH, skipping this shim
+SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+REAL_AWS=$(which -a aws 2>/dev/null | grep -v "$SELF" | head -1)
+if [[ -z "$REAL_AWS" ]]; then
+    echo "aws: real binary not found in PATH" >&2
+    exit 1
+fi
 TIMEOUT=600
 
 # Pass through if not "eks get-token"


### PR DESCRIPTION
## Summary

- Replaces hardcoded `/Users/etarn/.toolbox/bin/ada` and `/usr/local/bin/aws` with dynamic resolution via `which -a`, skipping the shim itself
- Fixes breakage on dev desktops where the real binaries live at different paths (e.g. `/local/home/etarn/.toolbox/bin/ada`)