### PR TITLE
Fix tmux UTF-8 mode for iTerm2 control mode

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -2,7 +2,7 @@ alias terraform='tofu'
 alias watch="viddy "
 alias kdebug='kubectl run -l debug=$USER -it --image ellistarn/debug $USER-debug-$RANDOM'
 alias kdebugcleanup='kubectl get pods -l debug=$USER --no-headers=true | cut -f1 -d " " | xargs kubectl delete pods'
-alias ssh-dev="ssh -t $DEV_DESKTOP_HOST 'tmux -CC new -A -s main'"
+alias ssh-dev="ssh -t $DEV_DESKTOP_HOST 'tmux -u -CC new -A -s main'"
 alias q="kiro-cli"
 
 #alias code=kiro


### PR DESCRIPTION
## Summary
- Add `-u` flag to tmux in `ssh-dev` alias to force UTF-8 mode, fixing the "UTF-8 Mode Not Detected" dialog in iTerm2's tmux control mode integration.
- Required for OpenCode and other tools that emit Unicode characters.