### PR TITLE
fix: correct orchestrator todowrite permission name

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "autoupdate": false,
   "plugin": [
     "opencode-wakelock"
   ],
@@ -80,7 +81,7 @@
         "task": "allow",
         "question": "allow",
         "skill": "allow",
-        "todo": "allow"
+        "todowrite": "allow"
       }
     },
     "muse": {


### PR DESCRIPTION
The orchestrator agent had `"todo": "allow"` in its permission block, but the tool's internal ID in OpenCode is `todowrite`. The mismatch meant the permission never matched, falling through to `"*": "deny"`, so the tool was never surfaced to the agent.

Fixed by renaming to `"todowrite": "allow"`. Verified by spawning an OpenCode orchestrator session that successfully used the TodoWrite tool.