### PR TITLE
fix(ada): validate credential Expiration before serving from cache

### DIFF
--- a/bin/ada
+++ b/bin/ada
@@ -42,21 +42,33 @@ for cache in /tmp/ada_credentials_*; do
     [[ $AGE -gt $TIMEOUT ]] && rm -f "$cache"
 done
 
-# Serve from cache if fresh
+# Serve from cache if fresh and not near expiration
 if [[ -f "$CACHE_FILE" ]]; then
     AGE=$(($(date +%s) - $(get_mtime "$CACHE_FILE")))
     if [[ $AGE -le $TIMEOUT ]]; then
-        cat "$CACHE_FILE"
-        exit 0
+        # Check the credential's actual Expiration field
+        EXPIRATION=$(grep -o '"Expiration":"[^"]*"' "$CACHE_FILE" | cut -d'"' -f4)
+        if [[ -n "$EXPIRATION" ]]; then
+            if [[ "$OSTYPE" == "darwin"* ]]; then
+                EXP_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$EXPIRATION" +%s 2>/dev/null)
+            else
+                EXP_EPOCH=$(date -d "$EXPIRATION" +%s 2>/dev/null)
+            fi
+            NOW=$(date +%s)
+            REMAINING=$((EXP_EPOCH - NOW))
+            if [[ $REMAINING -gt 300 ]]; then
+                cat "$CACHE_FILE"
+                exit 0
+            fi
+        fi
     fi
 fi
 
 # Cache miss — call real ada
-CREDENTIALS=$("$REAL_ADA" "${args[@]}" 2>&1)
+CREDENTIALS=$("$REAL_ADA" "${args[@]}")
 RC=$?
 if [[ $RC -eq 0 ]]; then
     echo "$CREDENTIALS" | tee "$CACHE_FILE"
 else
-    echo "$CREDENTIALS" >&2
     exit $RC
 fi


### PR DESCRIPTION
## Summary

- The ada credential cacher shim was serving expired credentials because it relied solely on file mtime (<900s) for freshness, ignoring the credential's actual `Expiration` timestamp
- Now parses the `Expiration` field from cached JSON and requires >5 minutes remaining before serving from cache
- Removed `2>&1` from the real ada invocation to prevent caching stderr garbage on warnings

## Root Cause

If ada's internal cache returned a partially-consumed credential (e.g., one with only 10 minutes remaining), the shim would cache it and serve it for up to 15 minutes — well past its actual expiration. This caused auth timeouts in OpenCode/Bedrock calls. Deleting the cache file from `/tmp` forced a fresh fetch, which is why manual removal was a workaround.