### PR TITLE
feat(opencode): grant explore agent external directory read access

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -67,7 +67,8 @@
       "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6",
       "permission": {
         "doom_loop": "deny",
-        "external_directory": "allow"
+        "external_directory": "allow",
+        "bash": "deny"
       }
     },
     "orchestrator": {

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -67,7 +67,7 @@
       "model": "amazon-bedrock/us.anthropic.claude-sonnet-4-6",
       "permission": {
         "doom_loop": "deny",
-        "external_directory": "deny"
+        "external_directory": "allow"
       }
     },
     "orchestrator": {


### PR DESCRIPTION
## Summary
- Flips `external_directory` from `deny` to `allow` for the explore agent
- Enables the orchestrator to dispatch explore to read files outside the workspace (e.g., reference repos, config files) without prompting
- Structurally safe: explore has no Edit, Write, or Bash tools — it cannot modify external files

## Tested
- `opencode run --agent orchestrator` successfully dispatched explore to read `/tmp/opencode/external-test.txt`
- Confirmed orchestrator -> explore -> read external path works end-to-end