### PR TITLE
feat(opencode): remove muse MCP server, grant orchestrator read access

### DIFF
--- a/.config/opencode/agents/orchestrator.md
+++ b/.config/opencode/agents/orchestrator.md
@@ -16,7 +16,9 @@ or do implementation work directly — even when the answer is obvious.
    computation belongs to the subagent.
 
 2. **You never do work directly.** You decompose, dispatch, verify, and re-decompose
-   on failure. That is the complete set of things you do.
+   on failure. That is the complete set of things you do. You may read files to
+   inform decomposition — understanding the shape of code before dispatching is
+   legitimate — but reading is not a substitute for dispatching verification tasks.
 
 ## How tasks work
 

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -62,7 +62,7 @@
       }
     },
     "orchestrator": {
-      "description": "Decomposes work and dispatches subagents for speed and quality. Can read files directly for reconnaissance.",
+      "description": "Decomposes work and dispatches subagents for speed and quality. Cannot edit files directly.",
       "mode": "primary",
       "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
       "variant": "high",

--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -29,22 +29,12 @@
         "InternalCodeSearch,InternalSearch,ReadInternalWebsites,WorkspaceSearch,WorkspaceGitDetails,BrazilBuildAnalyzerTool"
       ],
       "enabled": false
-    },
-    "ellis": {
-      "type": "local",
-      "command": ["{env:HOME}/go/bin/muse", "listen"],
-      "enabled": false,
-      "timeout": 120000,
-      "environment": {
-        "MUSE_MODEL": "us.anthropic.claude-opus-4-6-v1"
-      }
     }
   },
   "permission": {},
   "instructions": [],
   "tools": {
-    "builder-mcp_*": true,
-    "ellis_*": true
+    "builder-mcp_*": true
   },
   "agent": {
     "build": {
@@ -72,7 +62,7 @@
       }
     },
     "orchestrator": {
-      "description": "Decomposes work and dispatches subagents for speed and quality. Cannot read or edit files directly.",
+      "description": "Decomposes work and dispatches subagents for speed and quality. Can read files directly for reconnaissance.",
       "mode": "primary",
       "model": "amazon-bedrock/us.anthropic.claude-opus-4-6-v1",
       "variant": "high",
@@ -82,7 +72,10 @@
         "task": "allow",
         "question": "allow",
         "skill": "allow",
-        "todowrite": "allow"
+        "todowrite": "allow",
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow"
       }
     },
     "muse": {


### PR DESCRIPTION
## Summary

- Remove the `ellis` (muse listen) MCP server entry and its `ellis_*` tool grant — the muse agent remains as a subagent but no longer needs a dedicated MCP process.
- Grant the orchestrator agent `read`, `glob`, and `grep` permissions so it can do its own codebase reconnaissance before decomposing work into subagent tasks.