### PR TITLE
fix: kubectl tab completion broken by antigen precmd hook

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -126,10 +126,10 @@ zstyle ':completion:*' matcher-list '' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 
 zstyle ':completion:*' insert-tab pending                                       # pasting with tabs doesn't perform completion
 zstyle ':completion:*' completer _expand _complete _files _correct _approximate # default to file completion
 
+fpath=(~/.zsh/completions $fpath)
 autoload -Uz compinit && compinit
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
 [[ -r "/usr/local/bin/aws_completer" ]] && complete -C "/usr/local/bin/aws_completer" aws
-source <(kubectl completion zsh)
 
 function instanceid() {
   kubectl get node $1 -ojson | jq -r ".spec.providerID" | cut -f5 -d'/'


### PR DESCRIPTION
## Summary

- Replace `source <(kubectl completion zsh)` with fpath-based discovery so kubectl completion survives antigen's precmd `compinit` re-initialization.

## Root Cause

Antigen's static cache (`~/.antigen/init.zsh`) registers `_antigen_compinit` as a precmd hook that calls `compinit` **after** `.zshrc` finishes. This wipes in-memory-only `compdef` registrations (like kubectl's) because they aren't discoverable from fpath.

On macOS this was never an issue because homebrew installs `_kubectl` into `/opt/homebrew/share/zsh/site-functions/` (which is in fpath).

## Setup

One-time after merge:
```sh
mkdir -p ~/.zsh/completions
kubectl completion zsh > ~/.zsh/completions/_kubectl
```